### PR TITLE
Implemetación de isEquals para MLButtonConfig

### DIFF
--- a/LibraryComponents/MLButton/classes/MLButtonConfig.m
+++ b/LibraryComponents/MLButton/classes/MLButtonConfig.m
@@ -10,4 +10,32 @@
 
 @implementation MLButtonConfig
 
+- (BOOL)isEqualToButtonConfig:(MLButtonConfig *)buttonConfig
+{
+    if (!buttonConfig) {
+        return NO;
+    }
+    BOOL haveEqualDefaultState = (!self.defaultState && !buttonConfig.defaultState) || [self.defaultState isEqual:buttonConfig.defaultState];
+    BOOL haveEqualHighlightedState = (!self.highlightedState && !buttonConfig.highlightedState) || [self.highlightedState isEqual:buttonConfig.highlightedState];
+    BOOL haveEqualDisableState = (!self.disableState && !buttonConfig.disableState) || [self.disableState isEqual:buttonConfig.disableState];
+    BOOL haveEqualLoadingState = (!self.loadingState && !buttonConfig.loadingState) || [self.loadingState isEqual:buttonConfig.loadingState];
+    return haveEqualDefaultState && haveEqualHighlightedState && haveEqualDisableState && haveEqualLoadingState;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object) {
+        return YES;
+    }
+    if (![object isKindOfClass:MLButtonConfig.class]) {
+        return NO;
+    }
+    return [self isEqualToButtonConfig:(MLButtonConfig *)object];
+}
+
+- (NSUInteger)hash
+{
+    return self.defaultState.hash ^ self.highlightedState.hash ^ self.disableState.hash ^ self.loadingState.hash;
+}
+
 @end

--- a/LibraryComponents/MLButton/classes/MLButtonConfig.m
+++ b/LibraryComponents/MLButton/classes/MLButtonConfig.m
@@ -12,30 +12,30 @@
 
 - (BOOL)isEqualToButtonConfig:(MLButtonConfig *)buttonConfig
 {
-    if (!buttonConfig) {
-        return NO;
-    }
-    BOOL haveEqualDefaultState = (!self.defaultState && !buttonConfig.defaultState) || [self.defaultState isEqual:buttonConfig.defaultState];
-    BOOL haveEqualHighlightedState = (!self.highlightedState && !buttonConfig.highlightedState) || [self.highlightedState isEqual:buttonConfig.highlightedState];
-    BOOL haveEqualDisableState = (!self.disableState && !buttonConfig.disableState) || [self.disableState isEqual:buttonConfig.disableState];
-    BOOL haveEqualLoadingState = (!self.loadingState && !buttonConfig.loadingState) || [self.loadingState isEqual:buttonConfig.loadingState];
-    return haveEqualDefaultState && haveEqualHighlightedState && haveEqualDisableState && haveEqualLoadingState;
+	if (!buttonConfig) {
+		return NO;
+	}
+	BOOL haveEqualDefaultState = (!self.defaultState && !buttonConfig.defaultState) || [self.defaultState isEqual:buttonConfig.defaultState];
+	BOOL haveEqualHighlightedState = (!self.highlightedState && !buttonConfig.highlightedState) || [self.highlightedState isEqual:buttonConfig.highlightedState];
+	BOOL haveEqualDisableState = (!self.disableState && !buttonConfig.disableState) || [self.disableState isEqual:buttonConfig.disableState];
+	BOOL haveEqualLoadingState = (!self.loadingState && !buttonConfig.loadingState) || [self.loadingState isEqual:buttonConfig.loadingState];
+	return haveEqualDefaultState && haveEqualHighlightedState && haveEqualDisableState && haveEqualLoadingState;
 }
 
 - (BOOL)isEqual:(id)object
 {
-    if (self == object) {
-        return YES;
-    }
-    if (![object isKindOfClass:MLButtonConfig.class]) {
-        return NO;
-    }
-    return [self isEqualToButtonConfig:(MLButtonConfig *)object];
+	if (self == object) {
+		return YES;
+	}
+	if (![object isKindOfClass:MLButtonConfig.class]) {
+		return NO;
+	}
+	return [self isEqualToButtonConfig:(MLButtonConfig *)object];
 }
 
 - (NSUInteger)hash
 {
-    return self.defaultState.hash ^ self.highlightedState.hash ^ self.disableState.hash ^ self.loadingState.hash;
+	return self.defaultState.hash ^ self.highlightedState.hash ^ self.disableState.hash ^ self.loadingState.hash;
 }
 
 @end

--- a/LibraryComponents/MLButton/classes/MLButtonConfigStyle.h
+++ b/LibraryComponents/MLButton/classes/MLButtonConfigStyle.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <UIKit/UIKit.h>
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Use this interface to create the button custom style configuration
@@ -17,8 +17,10 @@
 @property (nonatomic, strong) UIColor *backgroundColor;
 @property (nonatomic, strong) UIColor *borderColor;
 
-- (instancetype)init __attribute__((unavailable("Must use initWithSize:primaryColor:secondaryColor: instead.")));
+- (instancetype)init __attribute__((unavailable("Must use initWithContentColor:backgroundColor:borderColor: instead.")));
 
 - (instancetype)initWithContentColor:(UIColor *)contentColor backgroundColor:(UIColor *)backgroundColor borderColor:(UIColor *)borderColor;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/LibraryComponents/MLButton/classes/MLButtonConfigStyle.m
+++ b/LibraryComponents/MLButton/classes/MLButtonConfigStyle.m
@@ -20,4 +20,31 @@
 	return self;
 }
 
+- (BOOL)isEqualToButtonConfigStyle:(MLButtonConfigStyle *)buttonConfigStyle
+{
+    if (!buttonConfigStyle) {
+        return NO;
+    }
+    BOOL haveEqualContentColor = (!self.contentColor && !buttonConfigStyle.contentColor) || [self.contentColor isEqual:buttonConfigStyle.contentColor];
+    BOOL haveEqualBackgroundColor = (!self.backgroundColor && !buttonConfigStyle.backgroundColor) || [self.backgroundColor isEqual:buttonConfigStyle.backgroundColor];
+    BOOL haveEqualBorderColor = (!self.borderColor && !buttonConfigStyle.borderColor) || [self.borderColor isEqual:buttonConfigStyle.borderColor];
+    return haveEqualContentColor && haveEqualBackgroundColor && haveEqualBorderColor;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (self == object) {
+        return YES;
+    }
+    if (![object isKindOfClass:MLButtonConfigStyle.class]) {
+        return NO;
+    }
+    return [self isEqualToButtonConfigStyle:(MLButtonConfigStyle *)object];
+}
+
+- (NSUInteger)hash
+{
+    return self.contentColor.hash ^ self.backgroundColor.hash ^ self.borderColor.hash;
+}
+
 @end

--- a/LibraryComponents/MLButton/classes/MLButtonConfigStyle.m
+++ b/LibraryComponents/MLButton/classes/MLButtonConfigStyle.m
@@ -22,29 +22,29 @@
 
 - (BOOL)isEqualToButtonConfigStyle:(MLButtonConfigStyle *)buttonConfigStyle
 {
-    if (!buttonConfigStyle) {
-        return NO;
-    }
-    BOOL haveEqualContentColor = (!self.contentColor && !buttonConfigStyle.contentColor) || [self.contentColor isEqual:buttonConfigStyle.contentColor];
-    BOOL haveEqualBackgroundColor = (!self.backgroundColor && !buttonConfigStyle.backgroundColor) || [self.backgroundColor isEqual:buttonConfigStyle.backgroundColor];
-    BOOL haveEqualBorderColor = (!self.borderColor && !buttonConfigStyle.borderColor) || [self.borderColor isEqual:buttonConfigStyle.borderColor];
-    return haveEqualContentColor && haveEqualBackgroundColor && haveEqualBorderColor;
+	if (!buttonConfigStyle) {
+		return NO;
+	}
+	BOOL haveEqualContentColor = (!self.contentColor && !buttonConfigStyle.contentColor) || [self.contentColor isEqual:buttonConfigStyle.contentColor];
+	BOOL haveEqualBackgroundColor = (!self.backgroundColor && !buttonConfigStyle.backgroundColor) || [self.backgroundColor isEqual:buttonConfigStyle.backgroundColor];
+	BOOL haveEqualBorderColor = (!self.borderColor && !buttonConfigStyle.borderColor) || [self.borderColor isEqual:buttonConfigStyle.borderColor];
+	return haveEqualContentColor && haveEqualBackgroundColor && haveEqualBorderColor;
 }
 
 - (BOOL)isEqual:(id)object
 {
-    if (self == object) {
-        return YES;
-    }
-    if (![object isKindOfClass:MLButtonConfigStyle.class]) {
-        return NO;
-    }
-    return [self isEqualToButtonConfigStyle:(MLButtonConfigStyle *)object];
+	if (self == object) {
+		return YES;
+	}
+	if (![object isKindOfClass:MLButtonConfigStyle.class]) {
+		return NO;
+	}
+	return [self isEqualToButtonConfigStyle:(MLButtonConfigStyle *)object];
 }
 
 - (NSUInteger)hash
 {
-    return self.contentColor.hash ^ self.backgroundColor.hash ^ self.borderColor.hash;
+	return self.contentColor.hash ^ self.backgroundColor.hash ^ self.borderColor.hash;
 }
 
 @end

--- a/MLUI.xcodeproj/project.pbxproj
+++ b/MLUI.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		CD141FA719C14A9600DBF568 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CD141F9F19C14A9600DBF568 /* main.m */; };
 		CD141FA819C14A9600DBF568 /* LegacyExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CD141FA119C14A9600DBF568 /* LegacyExampleViewController.m */; };
 		D0C5E4722034E0F000CA7136 /* MLStyleSheetManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C5E4712034E0F000CA7136 /* MLStyleSheetManagerTest.m */; };
+		D0D51EDC20D2CAD70044DF13 /* MLButtonConfigTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D51EDB20D2CAD70044DF13 /* MLButtonConfigTest.m */; };
+		D0D51EDE20D2D3930044DF13 /* MLButtonConfigStyleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D0D51EDD20D2D3930044DF13 /* MLButtonConfigStyleTest.m */; };
 		EE014FB61ECE185B00372EBB /* MLTextViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EE014FB41ECE185B00372EBB /* MLTextViewController.m */; };
 		EE014FB71ECE185B00372EBB /* MLTextViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = EE014FB51ECE185B00372EBB /* MLTextViewController.xib */; };
 		EEE5C8F01ED33426004D99A7 /* MLTextViewTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE5C8EF1ED33426004D99A7 /* MLTextViewTest.m */; };
@@ -143,7 +145,7 @@
 		4D4641C01C89DF9700459E27 /* MLSnackbarTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MLSnackbarTest.m; path = MLSnackbar/classes/MLSnackbarTest.m; sourceTree = "<group>"; };
 		4D4D35071D51405B00A6E637 /* MLStyle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MLStyle.h; path = MLSpacing/classes/MLStyle.h; sourceTree = "<group>"; };
 		4D5B06621C5BD01D000E7378 /* UIColor+MLColorPaletteTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+MLColorPaletteTest.m"; path = "MLColorPalette/UIColor+MLColorPaletteTest.m"; sourceTree = "<group>"; };
-		4D5B06651C5BD3D2000E7378 /* MLButtonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MLButtonTest.m; path = MLButton/MLButtonTest.m; sourceTree = "<group>"; };
+		4D5B06651C5BD3D2000E7378 /* MLButtonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLButtonTest.m; sourceTree = "<group>"; };
 		4D8906691C80850600BD0EEE /* MLSnackbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MLSnackbar.h; path = MLSnackBar/classes/MLSnackbar.h; sourceTree = "<group>"; };
 		4D89066A1C80850600BD0EEE /* MLSnackbar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MLSnackbar.m; path = MLSnackBar/classes/MLSnackbar.m; sourceTree = "<group>"; };
 		4D89066C1C80861C00BD0EEE /* MLSnackbar.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = MLSnackbar.xib; path = MLSnackBar/classes/MLSnackbar.xib; sourceTree = "<group>"; };
@@ -292,6 +294,8 @@
 		CD1B9F2319C3A497002EDF66 /* MLUIActionButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLUIActionButton.m; sourceTree = "<group>"; };
 		CFA85B1FBC9C408513BDECF7 /* Pods-MLUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MLUI.release.xcconfig"; path = "Pods/Target Support Files/Pods-MLUI/Pods-MLUI.release.xcconfig"; sourceTree = "<group>"; };
 		D0C5E4712034E0F000CA7136 /* MLStyleSheetManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLStyleSheetManagerTest.m; sourceTree = "<group>"; };
+		D0D51EDB20D2CAD70044DF13 /* MLButtonConfigTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLButtonConfigTest.m; sourceTree = "<group>"; };
+		D0D51EDD20D2D3930044DF13 /* MLButtonConfigStyleTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLButtonConfigStyleTest.m; sourceTree = "<group>"; };
 		EE014FB11ECDFCEC00372EBB /* MLGrowingTextViewHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MLGrowingTextViewHandler.h; sourceTree = "<group>"; };
 		EE014FB21ECDFCEC00372EBB /* MLGrowingTextViewHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLGrowingTextViewHandler.m; sourceTree = "<group>"; };
 		EE014FB31ECE185B00372EBB /* MLTextViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MLTextViewController.h; sourceTree = "<group>"; };
@@ -530,8 +534,10 @@
 			isa = PBXGroup;
 			children = (
 				4D5B06651C5BD3D2000E7378 /* MLButtonTest.m */,
+				D0D51EDB20D2CAD70044DF13 /* MLButtonConfigTest.m */,
+				D0D51EDD20D2D3930044DF13 /* MLButtonConfigStyleTest.m */,
 			);
-			name = MLButton;
+			path = MLButton;
 			sourceTree = "<group>";
 		};
 		4D8906671C8084D100BD0EEE /* MLSnackbar */ = {
@@ -1574,12 +1580,14 @@
 				4DF4CF1B1CCFD415002EC519 /* MLSpinnerTest.m in Sources */,
 				4DC842601D67511600ABA455 /* MLCheckListTest.m in Sources */,
 				6A44593B1D22D3630069EFBC /* MLRadioButtonCollectionTest.m in Sources */,
+				D0D51EDC20D2CAD70044DF13 /* MLButtonConfigTest.m in Sources */,
 				BB6573132040588700FBE8DD /* MLModalStyleFactoryTest.m in Sources */,
 				4D4641C11C89DF9700459E27 /* MLSnackbarTest.m in Sources */,
 				8664252B1CECC6E900888CAA /* MLTitledSingleLineTextFieldTest.m in Sources */,
 				4D5B06661C5BD3D2000E7378 /* MLButtonTest.m in Sources */,
 				4C926D401E5F6AA30028DFFB /* MLGenericErrorViewTest.m in Sources */,
 				D0C5E4722034E0F000CA7136 /* MLStyleSheetManagerTest.m in Sources */,
+				D0D51EDE20D2D3930044DF13 /* MLButtonConfigStyleTest.m in Sources */,
 				4D1B1D811CAAEC40003571C1 /* MLModalTest.m in Sources */,
 				4F01D2F01A67F0C400D88C9A /* UIColor+ThemeTest.m in Sources */,
 				4D5B06631C5BD01D000E7378 /* UIColor+MLColorPaletteTest.m in Sources */,

--- a/MLUIUnitTests/MLButton/MLButtonConfigStyleTest.m
+++ b/MLUIUnitTests/MLButton/MLButtonConfigStyleTest.m
@@ -1,0 +1,50 @@
+//
+//  MLButtonConfigStyleTest.m
+//  MLUIUnitTests
+//
+//  Created by Ezequiel Perez Dittler on 14/06/2018.
+//  Copyright © 2018 MercadoLibre. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <MLUI/MLButtonConfigStyle.h>
+
+@interface MLButtonConfigStyleTest : XCTestCase
+
+@end
+
+@implementation MLButtonConfigStyleTest
+
+- (void)testEqualsSelf {
+    MLButtonConfigStyle *style = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+    XCTAssertTrue([style isEqual:style]);
+}
+
+- (void)testEqualNotNilWithNil {
+    MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+    MLButtonConfigStyle *styleTwo = nil;
+    XCTAssertNotEqual(styleOne, styleTwo);
+    XCTAssertNotEqualObjects(styleOne, styleTwo);
+    XCTAssertNotEqualObjects(styleTwo, styleOne);
+    XCTAssertNotEqual(styleOne.hash, styleTwo.hash);
+}
+
+- (void)testEqualStyles {
+    MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+    MLButtonConfigStyle *styleTwo = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+    XCTAssertNotEqual(styleOne, styleTwo);
+    XCTAssertEqualObjects(styleOne, styleTwo);
+    XCTAssertEqualObjects(styleTwo, styleOne);
+    XCTAssertEqual(styleOne.hash, styleTwo.hash);
+}
+
+- (void)testNotEqualStyles {
+    MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+    MLButtonConfigStyle *styleTwo = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.redColor];
+    XCTAssertNotEqual(styleOne, styleTwo);
+    XCTAssertNotEqualObjects(styleOne, styleTwo);
+    XCTAssertNotEqualObjects(styleTwo, styleOne);
+    XCTAssertNotEqual(styleOne.hash, styleTwo.hash);
+}
+
+@end

--- a/MLUIUnitTests/MLButton/MLButtonConfigStyleTest.m
+++ b/MLUIUnitTests/MLButton/MLButtonConfigStyleTest.m
@@ -1,9 +1,9 @@
 //
-//  MLButtonConfigStyleTest.m
-//  MLUIUnitTests
+// MLButtonConfigStyleTest.m
+// MLUIUnitTests
 //
-//  Created by Ezequiel Perez Dittler on 14/06/2018.
-//  Copyright © 2018 MercadoLibre. All rights reserved.
+// Created by Ezequiel Perez Dittler on 14/06/2018.
+// Copyright © 2018 MercadoLibre. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>
@@ -15,36 +15,40 @@
 
 @implementation MLButtonConfigStyleTest
 
-- (void)testEqualsSelf {
-    MLButtonConfigStyle *style = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
-    XCTAssertTrue([style isEqual:style]);
+- (void)testEqualsSelf
+{
+	MLButtonConfigStyle *style = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+	XCTAssertTrue([style isEqual:style]);
 }
 
-- (void)testEqualNotNilWithNil {
-    MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
-    MLButtonConfigStyle *styleTwo = nil;
-    XCTAssertNotEqual(styleOne, styleTwo);
-    XCTAssertNotEqualObjects(styleOne, styleTwo);
-    XCTAssertNotEqualObjects(styleTwo, styleOne);
-    XCTAssertNotEqual(styleOne.hash, styleTwo.hash);
+- (void)testEqualNotNilWithNil
+{
+	MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+	MLButtonConfigStyle *styleTwo = nil;
+	XCTAssertNotEqual(styleOne, styleTwo);
+	XCTAssertNotEqualObjects(styleOne, styleTwo);
+	XCTAssertNotEqualObjects(styleTwo, styleOne);
+	XCTAssertNotEqual(styleOne.hash, styleTwo.hash);
 }
 
-- (void)testEqualStyles {
-    MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
-    MLButtonConfigStyle *styleTwo = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
-    XCTAssertNotEqual(styleOne, styleTwo);
-    XCTAssertEqualObjects(styleOne, styleTwo);
-    XCTAssertEqualObjects(styleTwo, styleOne);
-    XCTAssertEqual(styleOne.hash, styleTwo.hash);
+- (void)testEqualStyles
+{
+	MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+	MLButtonConfigStyle *styleTwo = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+	XCTAssertNotEqual(styleOne, styleTwo);
+	XCTAssertEqualObjects(styleOne, styleTwo);
+	XCTAssertEqualObjects(styleTwo, styleOne);
+	XCTAssertEqual(styleOne.hash, styleTwo.hash);
 }
 
-- (void)testNotEqualStyles {
-    MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
-    MLButtonConfigStyle *styleTwo = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.redColor];
-    XCTAssertNotEqual(styleOne, styleTwo);
-    XCTAssertNotEqualObjects(styleOne, styleTwo);
-    XCTAssertNotEqualObjects(styleTwo, styleOne);
-    XCTAssertNotEqual(styleOne.hash, styleTwo.hash);
+- (void)testNotEqualStyles
+{
+	MLButtonConfigStyle *styleOne = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.brownColor];
+	MLButtonConfigStyle *styleTwo = [[MLButtonConfigStyle alloc] initWithContentColor:UIColor.blueColor backgroundColor:UIColor.blackColor borderColor:UIColor.redColor];
+	XCTAssertNotEqual(styleOne, styleTwo);
+	XCTAssertNotEqualObjects(styleOne, styleTwo);
+	XCTAssertNotEqualObjects(styleTwo, styleOne);
+	XCTAssertNotEqual(styleOne.hash, styleTwo.hash);
 }
 
 @end

--- a/MLUIUnitTests/MLButton/MLButtonConfigTest.m
+++ b/MLUIUnitTests/MLButton/MLButtonConfigTest.m
@@ -1,0 +1,40 @@
+//
+//  MLButtonConfigTest.m
+//  MLUIUnitTests
+//
+//  Created by Ezequiel Perez Dittler on 14/06/2018.
+//  Copyright © 2018 MercadoLibre. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <MLUI/MLButtonConfig.h>
+
+@interface MLButtonConfigTest : XCTestCase
+
+@end
+
+@implementation MLButtonConfigTest
+
+- (void)testEqualsSelf {
+    MLButtonConfig *config = [[MLButtonConfig alloc] init];
+    XCTAssertTrue([config isEqual:config]);
+}
+
+- (void)testEqualsNotNilWithNil {
+    MLButtonConfig *configOne = [[MLButtonConfig alloc] init];
+    MLButtonConfig *configTwo = nil;
+    XCTAssertNotEqual(configOne, configTwo);
+    XCTAssertNotEqualObjects(configOne, configTwo);
+    XCTAssertNotEqualObjects(configTwo, configOne);
+}
+
+- (void)testEqualsEmptyConfigs {
+    MLButtonConfig *configOne = [[MLButtonConfig alloc] init];
+    MLButtonConfig *configTwo = [[MLButtonConfig alloc] init];
+    XCTAssertNotEqual(configOne, configTwo);
+    XCTAssertEqualObjects(configOne, configTwo);
+    XCTAssertEqualObjects(configTwo, configOne);
+    XCTAssertEqual(configOne.hash, configTwo.hash);
+}
+
+@end

--- a/MLUIUnitTests/MLButton/MLButtonConfigTest.m
+++ b/MLUIUnitTests/MLButton/MLButtonConfigTest.m
@@ -1,9 +1,9 @@
 //
-//  MLButtonConfigTest.m
-//  MLUIUnitTests
+// MLButtonConfigTest.m
+// MLUIUnitTests
 //
-//  Created by Ezequiel Perez Dittler on 14/06/2018.
-//  Copyright © 2018 MercadoLibre. All rights reserved.
+// Created by Ezequiel Perez Dittler on 14/06/2018.
+// Copyright © 2018 MercadoLibre. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>
@@ -15,26 +15,29 @@
 
 @implementation MLButtonConfigTest
 
-- (void)testEqualsSelf {
-    MLButtonConfig *config = [[MLButtonConfig alloc] init];
-    XCTAssertTrue([config isEqual:config]);
+- (void)testEqualsSelf
+{
+	MLButtonConfig *config = [[MLButtonConfig alloc] init];
+	XCTAssertTrue([config isEqual:config]);
 }
 
-- (void)testEqualsNotNilWithNil {
-    MLButtonConfig *configOne = [[MLButtonConfig alloc] init];
-    MLButtonConfig *configTwo = nil;
-    XCTAssertNotEqual(configOne, configTwo);
-    XCTAssertNotEqualObjects(configOne, configTwo);
-    XCTAssertNotEqualObjects(configTwo, configOne);
+- (void)testEqualsNotNilWithNil
+{
+	MLButtonConfig *configOne = [[MLButtonConfig alloc] init];
+	MLButtonConfig *configTwo = nil;
+	XCTAssertNotEqual(configOne, configTwo);
+	XCTAssertNotEqualObjects(configOne, configTwo);
+	XCTAssertNotEqualObjects(configTwo, configOne);
 }
 
-- (void)testEqualsEmptyConfigs {
-    MLButtonConfig *configOne = [[MLButtonConfig alloc] init];
-    MLButtonConfig *configTwo = [[MLButtonConfig alloc] init];
-    XCTAssertNotEqual(configOne, configTwo);
-    XCTAssertEqualObjects(configOne, configTwo);
-    XCTAssertEqualObjects(configTwo, configOne);
-    XCTAssertEqual(configOne.hash, configTwo.hash);
+- (void)testEqualsEmptyConfigs
+{
+	MLButtonConfig *configOne = [[MLButtonConfig alloc] init];
+	MLButtonConfig *configTwo = [[MLButtonConfig alloc] init];
+	XCTAssertNotEqual(configOne, configTwo);
+	XCTAssertEqualObjects(configOne, configTwo);
+	XCTAssertEqualObjects(configTwo, configOne);
+	XCTAssertEqual(configOne.hash, configTwo.hash);
 }
 
 @end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,98 +1,98 @@
 PODS:
   - FXBlurView (1.6.4)
   - JRSwizzle (1.0)
-  - MLUI (3.2.0):
-    - MLUI/ActionButton (= 3.2.0)
-    - MLUI/Core (= 3.2.0)
-    - MLUI/Helpers (= 3.2.0)
-    - MLUI/MLButton (= 3.2.0)
-    - MLUI/MLCheckBox (= 3.2.0)
-    - MLUI/MLColorPalette (= 3.2.0)
-    - MLUI/MLContextualMenu (= 3.2.0)
-    - MLUI/MLFonts (= 3.2.0)
-    - MLUI/MLGenericErrorView (= 3.2.0)
-    - MLUI/MLHtml (= 3.2.0)
-    - MLUI/MLModal (= 3.2.0)
-    - MLUI/MLRadioButton (= 3.2.0)
-    - MLUI/MLSnackBar (= 3.2.0)
-    - MLUI/MLSpacing (= 3.2.0)
-    - MLUI/MLSpinner (= 3.2.0)
-    - MLUI/MLSwitch (= 3.2.0)
-    - MLUI/MLTextView (= 3.2.0)
-    - MLUI/MLTitledMultiLineTextField (= 3.2.0)
-    - MLUI/MLTitledSingleLineTextField (= 3.2.0)
-    - MLUI/PriceView (= 3.2.0)
-    - MLUI/SnackBarView (= 3.2.0)
-    - MLUI/StyleSheet (= 3.2.0)
-  - MLUI/ActionButton (3.2.0):
+  - MLUI (4.0.0):
+    - MLUI/ActionButton (= 4.0.0)
+    - MLUI/Core (= 4.0.0)
+    - MLUI/Helpers (= 4.0.0)
+    - MLUI/MLButton (= 4.0.0)
+    - MLUI/MLCheckBox (= 4.0.0)
+    - MLUI/MLColorPalette (= 4.0.0)
+    - MLUI/MLContextualMenu (= 4.0.0)
+    - MLUI/MLFonts (= 4.0.0)
+    - MLUI/MLGenericErrorView (= 4.0.0)
+    - MLUI/MLHtml (= 4.0.0)
+    - MLUI/MLModal (= 4.0.0)
+    - MLUI/MLRadioButton (= 4.0.0)
+    - MLUI/MLSnackBar (= 4.0.0)
+    - MLUI/MLSpacing (= 4.0.0)
+    - MLUI/MLSpinner (= 4.0.0)
+    - MLUI/MLSwitch (= 4.0.0)
+    - MLUI/MLTextView (= 4.0.0)
+    - MLUI/MLTitledMultiLineTextField (= 4.0.0)
+    - MLUI/MLTitledSingleLineTextField (= 4.0.0)
+    - MLUI/PriceView (= 4.0.0)
+    - MLUI/SnackBarView (= 4.0.0)
+    - MLUI/StyleSheet (= 4.0.0)
+  - MLUI/ActionButton (4.0.0):
     - MLUI/Core
-  - MLUI/Core (3.2.0):
+  - MLUI/Core (4.0.0):
     - MLUI/MLFonts
-  - MLUI/Helpers (3.2.0)
-  - MLUI/MLButton (3.2.0):
+  - MLUI/Helpers (4.0.0)
+  - MLUI/MLButton (4.0.0):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/MLSpinner
     - MLUI/StyleSheet
-  - MLUI/MLCheckBox (3.2.0):
+  - MLUI/MLCheckBox (4.0.0):
     - MLUI/MLColorPalette
-  - MLUI/MLColorPalette (3.2.0)
-  - MLUI/MLContextualMenu (3.2.0):
+  - MLUI/MLColorPalette (4.0.0)
+  - MLUI/MLContextualMenu (4.0.0):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
-  - MLUI/MLFonts (3.2.0):
+  - MLUI/MLFonts (4.0.0):
     - JRSwizzle (= 1.0)
     - MLUI/Helpers
     - MLUI/StyleSheet
-  - MLUI/MLGenericErrorView (3.2.0):
+  - MLUI/MLGenericErrorView (4.0.0):
     - MLUI/MLButton
     - MLUI/MLColorPalette
     - MLUI/MLSpacing
-  - MLUI/MLHtml (3.2.0):
+  - MLUI/MLHtml (4.0.0):
     - MLUI/MLFonts
-  - MLUI/MLModal (3.2.0):
+  - MLUI/MLModal (4.0.0):
     - FXBlurView (~> 1.6)
     - MLUI/Core
     - MLUI/MLButton
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/StyleSheet
-  - MLUI/MLRadioButton (3.2.0):
+  - MLUI/MLRadioButton (4.0.0):
     - MLUI/MLColorPalette
-  - MLUI/MLSnackBar (3.2.0):
+  - MLUI/MLSnackBar (4.0.0):
     - MLUI/Helpers
     - MLUI/MLButton
     - MLUI/MLColorPalette
     - MLUI/MLFonts
-  - MLUI/MLSpacing (3.2.0):
+  - MLUI/MLSpacing (4.0.0):
     - JRSwizzle (= 1.0)
     - MLUI/MLFonts
-  - MLUI/MLSpinner (3.2.0):
+  - MLUI/MLSpinner (4.0.0):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/StyleSheet
-  - MLUI/MLSwitch (3.2.0):
+  - MLUI/MLSwitch (4.0.0):
     - MLUI/Helpers
     - MLUI/MLColorPalette
-  - MLUI/MLTextView (3.2.0):
+  - MLUI/MLTextView (4.0.0):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
-  - MLUI/MLTitledMultiLineTextField (3.2.0):
+  - MLUI/MLTitledMultiLineTextField (4.0.0):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/MLTitledSingleLineTextField
     - MLUI/StyleSheet
-  - MLUI/MLTitledSingleLineTextField (3.2.0):
+  - MLUI/MLTitledSingleLineTextField (4.0.0):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/StyleSheet
-  - MLUI/PriceView (3.2.0):
+  - MLUI/PriceView (4.0.0):
     - MLUI/Core
     - MLUI/MLFonts
-  - MLUI/SnackBarView (3.2.0):
+  - MLUI/SnackBarView (4.0.0):
     - MLUI/Helpers
     - MLUI/MLFonts
-  - MLUI/StyleSheet (3.2.0)
+  - MLUI/StyleSheet (4.0.0)
   - OCMock (3.3.1)
 
 DEPENDENCIES:
@@ -107,9 +107,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
-  MLUI: 41e1d9a6389c9ab9e3010fd7dd4dddf3c229905a
+  MLUI: d768815357f23d0ef61b0a95e80a0e016f494064
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
 
-PODFILE CHECKSUM: b0130f5fd6aea00617f14e817b6489c765e1f20d
+PODFILE CHECKSUM: e62da3accd1dd10c2d997fabcd3120201e30f5ab
 
 COCOAPODS: 1.4.0


### PR DESCRIPTION
Antes para verificar si un MLButton tenia el estilo correcto, bastaba con comparar el atributo `style`. Desde que ese atributo se encuentra deprecado, la forma de verificar si los estilos son los correctos, es comparar el atributo `config`. Como éstos son objetos, requieren de la implementación del método `isEquals` para que la comparación sera válida.