### PR TITLE
Feature/checkbox update

### DIFF
--- a/Example/MLBooleanWidget/MLBooleanWidgetViewController.m
+++ b/Example/MLBooleanWidget/MLBooleanWidgetViewController.m
@@ -45,7 +45,7 @@
 	[self setupTitle];
 	[self setupCheckBox];
 	[self setupCheckBoxLabels];
-    [self setupControlCheckbox];
+	[self setupControlCheckbox];
 	[self setupRadioButton];
 	[self setupOptionLabels];
 	[self setupSwitch];
@@ -64,8 +64,8 @@
 
 - (void)setupControlCheckbox
 {
-    [self.mlCheckBox3 onAnimated:NO];
-    self.mlCheckBox3.delegate = self;
+	[self.mlCheckBox3 onAnimated:NO];
+	self.mlCheckBox3.delegate = self;
 }
 
 - (void)setupCheckBoxLabels
@@ -94,11 +94,11 @@
 - (void)booleanWidgetDidRequestChangeOfState:(MLBooleanWidget *)booleanWidget
 {
 	[booleanWidget toggleAnimated:YES];
-    
-    if (booleanWidget == self.mlCheckBox3) {
-        [self.mlCheckBox1 setEnabled:booleanWidget.isOn Animated:YES];
-        [self.mlCheckBox2 setEnabled:booleanWidget.isOn Animated:YES];
-    }
+
+	if (booleanWidget == self.mlCheckBox3) {
+		[self.mlCheckBox1 setEnabled:booleanWidget.isOn Animated:YES];
+		[self.mlCheckBox2 setEnabled:booleanWidget.isOn Animated:YES];
+	}
 }
 
 #pragma mark - Actions

--- a/Example/MLBooleanWidget/MLBooleanWidgetViewController.m
+++ b/Example/MLBooleanWidget/MLBooleanWidgetViewController.m
@@ -20,6 +20,7 @@
 
 @property (weak, nonatomic) IBOutlet MLCheckBox *mlCheckBox1;
 @property (weak, nonatomic) IBOutlet MLCheckBox *mlCheckBox2;
+@property (weak, nonatomic) IBOutlet MLCheckBox *mlCheckBox3;
 
 @property (weak, nonatomic) IBOutlet MLRadioButton *mlRadioButton1;
 @property (weak, nonatomic) IBOutlet MLRadioButton *mlRadioButton2;
@@ -44,6 +45,7 @@
 	[self setupTitle];
 	[self setupCheckBox];
 	[self setupCheckBoxLabels];
+    [self setupControlCheckbox];
 	[self setupRadioButton];
 	[self setupOptionLabels];
 	[self setupSwitch];
@@ -58,6 +60,12 @@
 - (void)setupCheckBox
 {
 	self.mlCheckList = [MLCheckList checkListWithCheckBoxes:@[self.mlCheckBox1, self.mlCheckBox2]];
+}
+
+- (void)setupControlCheckbox
+{
+    [self.mlCheckBox3 onAnimated:NO];
+    self.mlCheckBox3.delegate = self;
 }
 
 - (void)setupCheckBoxLabels
@@ -86,6 +94,11 @@
 - (void)booleanWidgetDidRequestChangeOfState:(MLBooleanWidget *)booleanWidget
 {
 	[booleanWidget toggleAnimated:YES];
+    
+    if (booleanWidget == self.mlCheckBox3) {
+        [self.mlCheckBox1 setEnabled:booleanWidget.isOn Animated:YES];
+        [self.mlCheckBox2 setEnabled:booleanWidget.isOn Animated:YES];
+    }
 }
 
 #pragma mark - Actions

--- a/Example/MLBooleanWidget/MLBooleanWidgetViewController.xib
+++ b/Example/MLBooleanWidget/MLBooleanWidgetViewController.xib
@@ -1,11 +1,14 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="NO">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <development version="7000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MLBooleanWidgetViewController">
@@ -14,6 +17,7 @@
                 <outlet property="checkBox2Label" destination="dah-VB-JE4" id="Wkg-Gu-ZPs"/>
                 <outlet property="mlCheckBox1" destination="fUk-nQ-NPk" id="879-TQ-gGa"/>
                 <outlet property="mlCheckBox2" destination="xYv-fu-4hF" id="j4N-r6-cJa"/>
+                <outlet property="mlCheckBox3" destination="mul-8k-KC7" id="oJ1-YC-qyg"/>
                 <outlet property="mlRadioButton1" destination="WCK-Cb-XUk" id="f3D-px-8fT"/>
                 <outlet property="mlRadioButton2" destination="0xF-gW-hWD" id="V5r-cx-Ojk"/>
                 <outlet property="mlSwitch" destination="3w8-Xe-oKW" id="WGh-Em-b3d"/>
@@ -24,24 +28,24 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Afr-bT-2fE" userLabel="ContainerView">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Afr-bT-2fE" userLabel="ContainerView">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <subviews>
-                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k91-tZ-8yR" userLabel="RadioButtonView">
-                            <rect key="frame" x="8" y="152" width="359" height="128"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="k91-tZ-8yR" userLabel="RadioButtonView">
+                            <rect key="frame" x="8" y="184" width="359" height="128"/>
                             <subviews>
-                                <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hiH-Uy-euj">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hiH-Uy-euj">
                                     <rect key="frame" x="8" y="48" width="343" height="72"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aEY-1j-PR9">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aEY-1j-PR9">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WCK-Cb-XUk" customClass="MLRadioButton">
                                                     <rect key="frame" x="0.0" y="10.5" width="15" height="15"/>
-                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="15" id="3LV-Hm-ypy"/>
                                                         <constraint firstAttribute="width" secondItem="WCK-Cb-XUk" secondAttribute="height" multiplier="1:1" id="BJg-dG-sNC"/>
@@ -50,11 +54,11 @@
                                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Option 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rdd-Fl-D9W">
                                                     <rect key="frame" x="23" y="8" width="63.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstItem="Rdd-Fl-D9W" firstAttribute="centerY" secondItem="aEY-1j-PR9" secondAttribute="centerY" id="0AH-Nv-pe9"/>
                                                 <constraint firstItem="Rdd-Fl-D9W" firstAttribute="leading" secondItem="WCK-Cb-XUk" secondAttribute="trailing" constant="8" id="CqU-Y3-C76"/>
@@ -62,12 +66,12 @@
                                                 <constraint firstItem="WCK-Cb-XUk" firstAttribute="centerY" secondItem="aEY-1j-PR9" secondAttribute="centerY" id="xdx-Bc-lNt"/>
                                             </constraints>
                                         </view>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NYL-iP-fAq">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NYL-iP-fAq">
                                             <rect key="frame" x="0.0" y="36" width="343" height="36"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0xF-gW-hWD" customClass="MLRadioButton">
                                                     <rect key="frame" x="0.0" y="10.5" width="15" height="15"/>
-                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="0xF-gW-hWD" secondAttribute="height" multiplier="1:1" id="Nvn-Hd-9rs"/>
                                                         <constraint firstAttribute="width" constant="15" id="yZ9-K6-Q6b"/>
@@ -76,11 +80,11 @@
                                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Option 2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aMo-aP-CKq">
                                                     <rect key="frame" x="23" y="8" width="66" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstItem="0xF-gW-hWD" firstAttribute="leading" secondItem="NYL-iP-fAq" secondAttribute="leading" id="gl3-0u-ApI"/>
                                                 <constraint firstItem="aMo-aP-CKq" firstAttribute="centerY" secondItem="NYL-iP-fAq" secondAttribute="centerY" id="ipT-uR-hHO"/>
@@ -89,7 +93,7 @@
                                             </constraints>
                                         </view>
                                     </subviews>
-                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="bottom" secondItem="NYL-iP-fAq" secondAttribute="bottom" id="Caa-DS-ard"/>
                                         <constraint firstItem="NYL-iP-fAq" firstAttribute="top" secondItem="aEY-1j-PR9" secondAttribute="bottom" id="EDc-fw-BxY"/>
@@ -101,14 +105,14 @@
                                         <constraint firstItem="aEY-1j-PR9" firstAttribute="top" secondItem="hiH-Uy-euj" secondAttribute="top" id="z9T-jk-WwF"/>
                                     </constraints>
                                 </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RadioButton" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ri0-gv-13e">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="RadioButton" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ri0-gv-13e">
                                     <rect key="frame" x="8" y="8" width="110.5" height="24"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstItem="hiH-Uy-euj" firstAttribute="top" secondItem="ri0-gv-13e" secondAttribute="bottom" constant="16" id="JQT-y4-kPJ"/>
                                 <constraint firstItem="ri0-gv-13e" firstAttribute="leading" secondItem="k91-tZ-8yR" secondAttribute="leading" constant="8" id="OwR-3c-rR9"/>
@@ -125,34 +129,34 @@
                                 </mask>
                             </variation>
                         </view>
-                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Zy-mt-4rN" userLabel="SwitchesView">
-                            <rect key="frame" x="8" y="296" width="359" height="100"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Zy-mt-4rN" userLabel="SwitchesView">
+                            <rect key="frame" x="8" y="328" width="359" height="100"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Switch" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YY5-Dr-g70">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Switch" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YY5-Dr-g70">
                                     <rect key="frame" x="8" y="8" width="60.5" height="24"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2f6-Yb-Gm9">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2f6-Yb-Gm9">
                                     <rect key="frame" x="8" y="48" width="343" height="44"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Switch" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zlF-pt-34D">
                                             <rect key="frame" x="0.0" y="12" width="51.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3w8-Xe-oKW" customClass="MLSwitch">
                                             <rect key="frame" x="59.5" y="12" width="30" height="20"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="20" id="GfL-FF-UWl"/>
                                                 <constraint firstAttribute="width" constant="30" id="jhq-Rz-GvM"/>
                                             </constraints>
                                         </view>
                                     </subviews>
-                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstItem="3w8-Xe-oKW" firstAttribute="centerY" secondItem="2f6-Yb-Gm9" secondAttribute="centerY" id="7tZ-rA-vYT"/>
                                         <constraint firstItem="3w8-Xe-oKW" firstAttribute="leading" secondItem="zlF-pt-34D" secondAttribute="trailing" constant="8" id="Cgc-hm-NaD"/>
@@ -161,7 +165,7 @@
                                     </constraints>
                                 </view>
                             </subviews>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="2f6-Yb-Gm9" secondAttribute="bottom" constant="8" id="5nO-jt-0uL"/>
                                 <constraint firstItem="2f6-Yb-Gm9" firstAttribute="top" secondItem="YY5-Dr-g70" secondAttribute="bottom" constant="16" id="9zG-90-8Rp"/>
@@ -180,37 +184,37 @@
                                 </mask>
                             </variation>
                         </view>
-                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jXn-jX-uxg" userLabel="CheckBoxView">
-                            <rect key="frame" x="8" y="8" width="359" height="128"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jXn-jX-uxg" userLabel="CheckBoxView">
+                            <rect key="frame" x="8" y="8" width="359" height="160"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CheckBox" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tn6-FS-lzG">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="CheckBox" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tn6-FS-lzG">
                                     <rect key="frame" x="8" y="8" width="91.5" height="24"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="22v-IM-MuY">
-                                    <rect key="frame" x="8" y="48" width="343" height="72"/>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="22v-IM-MuY">
+                                    <rect key="frame" x="8" y="48" width="343" height="104"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qUb-Yg-ues">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="36"/>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qUb-Yg-ues">
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="34.5"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fUk-nQ-NPk" customClass="MLCheckBox">
                                                     <rect key="frame" x="0.0" y="10.5" width="15" height="15"/>
-                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="15" id="IQL-Nx-9Us"/>
                                                         <constraint firstAttribute="width" secondItem="fUk-nQ-NPk" secondAttribute="height" multiplier="1:1" id="YCs-nK-vOr"/>
                                                     </constraints>
                                                 </view>
                                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CheckBox1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7wz-aw-6BB">
-                                                    <rect key="frame" x="23" y="8" width="85" height="20.5"/>
+                                                    <rect key="frame" x="23" y="7" width="85" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstItem="7wz-aw-6BB" firstAttribute="centerY" secondItem="qUb-Yg-ues" secondAttribute="centerY" id="0u2-kX-35e"/>
                                                 <constraint firstItem="fUk-nQ-NPk" firstAttribute="leading" secondItem="qUb-Yg-ues" secondAttribute="leading" id="ejH-wb-5nh"/>
@@ -218,12 +222,12 @@
                                                 <constraint firstItem="7wz-aw-6BB" firstAttribute="leading" secondItem="fUk-nQ-NPk" secondAttribute="trailing" constant="8" id="xUz-F3-VdV"/>
                                             </constraints>
                                         </view>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="phM-hm-Bks">
-                                            <rect key="frame" x="0.0" y="36" width="343" height="36"/>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="phM-hm-Bks">
+                                            <rect key="frame" x="0.0" y="34.5" width="343" height="35"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xYv-fu-4hF" customClass="MLCheckBox">
                                                     <rect key="frame" x="0.0" y="10.5" width="15" height="15"/>
-                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="15" id="9Gv-hs-4ZM"/>
                                                         <constraint firstAttribute="width" secondItem="xYv-fu-4hF" secondAttribute="height" multiplier="1:1" id="eNu-Ua-Jec"/>
@@ -232,11 +236,11 @@
                                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CheckBox2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dah-VB-JE4">
                                                     <rect key="frame" x="23" y="8" width="87.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstItem="xYv-fu-4hF" firstAttribute="leading" secondItem="phM-hm-Bks" secondAttribute="leading" id="79i-bx-ot3"/>
                                                 <constraint firstItem="xYv-fu-4hF" firstAttribute="centerY" secondItem="phM-hm-Bks" secondAttribute="centerY" id="dc1-3f-5Wn"/>
@@ -244,33 +248,63 @@
                                                 <constraint firstItem="dah-VB-JE4" firstAttribute="leading" secondItem="xYv-fu-4hF" secondAttribute="trailing" constant="8" id="pnS-MK-adb"/>
                                             </constraints>
                                         </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a2K-Jh-gIJ">
+                                            <rect key="frame" x="0.0" y="69.5" width="343" height="34.5"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mul-8k-KC7" customClass="MLCheckBox">
+                                                    <rect key="frame" x="0.0" y="10.5" width="15" height="15"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="mul-8k-KC7" secondAttribute="height" multiplier="1:1" id="s2Q-YR-C7e"/>
+                                                        <constraint firstAttribute="width" constant="15" id="w4z-sj-abH"/>
+                                                    </constraints>
+                                                </view>
+                                                <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable Above Checkboxes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EQs-qx-UuI" userLabel="CheckBox3 Label">
+                                                    <rect key="frame" x="23" y="7" width="208" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <constraints>
+                                                <constraint firstItem="mul-8k-KC7" firstAttribute="centerY" secondItem="a2K-Jh-gIJ" secondAttribute="centerY" id="DuD-5J-jIC"/>
+                                                <constraint firstItem="EQs-qx-UuI" firstAttribute="leading" secondItem="mul-8k-KC7" secondAttribute="trailing" constant="8" id="E66-5f-YhY"/>
+                                                <constraint firstItem="EQs-qx-UuI" firstAttribute="centerY" secondItem="a2K-Jh-gIJ" secondAttribute="centerY" id="Sw4-pq-1za"/>
+                                                <constraint firstItem="mul-8k-KC7" firstAttribute="leading" secondItem="a2K-Jh-gIJ" secondAttribute="leading" id="uki-iI-dNf"/>
+                                            </constraints>
+                                        </view>
                                     </subviews>
-                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="trailing" secondItem="phM-hm-Bks" secondAttribute="trailing" id="4I6-ky-Zwt"/>
+                                        <constraint firstItem="a2K-Jh-gIJ" firstAttribute="leading" secondItem="22v-IM-MuY" secondAttribute="leading" id="4bP-0r-hPe"/>
                                         <constraint firstAttribute="trailing" secondItem="qUb-Yg-ues" secondAttribute="trailing" id="J0d-Nz-8DJ"/>
-                                        <constraint firstItem="qUb-Yg-ues" firstAttribute="height" secondItem="22v-IM-MuY" secondAttribute="height" multiplier="1/2" id="LOG-H5-SSy"/>
+                                        <constraint firstItem="qUb-Yg-ues" firstAttribute="height" secondItem="22v-IM-MuY" secondAttribute="height" multiplier="1/3" id="LOG-H5-SSy"/>
+                                        <constraint firstAttribute="trailing" secondItem="a2K-Jh-gIJ" secondAttribute="trailing" id="Zog-eZ-uka"/>
+                                        <constraint firstItem="a2K-Jh-gIJ" firstAttribute="top" secondItem="phM-hm-Bks" secondAttribute="bottom" id="at7-lm-94x"/>
                                         <constraint firstItem="phM-hm-Bks" firstAttribute="leading" secondItem="22v-IM-MuY" secondAttribute="leading" id="cQh-fo-cgm"/>
+                                        <constraint firstAttribute="bottom" secondItem="a2K-Jh-gIJ" secondAttribute="bottom" id="h5k-4C-woD"/>
                                         <constraint firstItem="qUb-Yg-ues" firstAttribute="top" secondItem="22v-IM-MuY" secondAttribute="top" id="lbv-Ki-fqe"/>
                                         <constraint firstItem="phM-hm-Bks" firstAttribute="top" secondItem="qUb-Yg-ues" secondAttribute="bottom" id="pBA-Qc-QJs"/>
-                                        <constraint firstAttribute="bottom" secondItem="phM-hm-Bks" secondAttribute="bottom" id="q0Z-LA-IJs"/>
                                         <constraint firstItem="qUb-Yg-ues" firstAttribute="leading" secondItem="22v-IM-MuY" secondAttribute="leading" id="w4G-zi-Hpc"/>
+                                        <constraint firstItem="phM-hm-Bks" firstAttribute="height" secondItem="22v-IM-MuY" secondAttribute="height" multiplier="1/3" id="ywu-Tb-npR"/>
                                     </constraints>
                                 </view>
                             </subviews>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="22v-IM-MuY" secondAttribute="trailing" constant="8" id="AMy-OD-PUi"/>
                                 <constraint firstItem="22v-IM-MuY" firstAttribute="top" secondItem="tn6-FS-lzG" secondAttribute="bottom" constant="16" id="K3V-X0-gsa"/>
                                 <constraint firstItem="22v-IM-MuY" firstAttribute="leading" secondItem="jXn-jX-uxg" secondAttribute="leading" constant="8" id="MLj-3m-nKM"/>
                                 <constraint firstItem="tn6-FS-lzG" firstAttribute="top" secondItem="jXn-jX-uxg" secondAttribute="top" constant="8" id="TTr-SU-Vh5"/>
                                 <constraint firstAttribute="bottom" secondItem="22v-IM-MuY" secondAttribute="bottom" constant="8" id="YdU-b2-poq"/>
-                                <constraint firstAttribute="height" constant="128" id="bUX-XT-r6c"/>
+                                <constraint firstAttribute="height" constant="160" id="bUX-XT-r6c"/>
                                 <constraint firstItem="tn6-FS-lzG" firstAttribute="leading" secondItem="jXn-jX-uxg" secondAttribute="leading" constant="8" id="fqy-i2-44H"/>
                             </constraints>
                         </view>
                     </subviews>
-                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="jXn-jX-uxg" secondAttribute="trailing" constant="8" id="DUl-lS-5me"/>
                         <constraint firstItem="jXn-jX-uxg" firstAttribute="leading" secondItem="Afr-bT-2fE" secondAttribute="leading" constant="8" id="Gcn-BO-Jh1"/>
@@ -284,7 +318,7 @@
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="Afr-bT-2fE" secondAttribute="bottom" id="60H-l5-ILn"/>
                 <constraint firstItem="Afr-bT-2fE" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="6SM-XB-WXY"/>

--- a/Example/MLBooleanWidget/MLBooleanWidgetViewController.xib
+++ b/Example/MLBooleanWidget/MLBooleanWidgetViewController.xib
@@ -259,8 +259,8 @@
                                                         <constraint firstAttribute="width" constant="15" id="w4z-sj-abH"/>
                                                     </constraints>
                                                 </view>
-                                                <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable Above Checkboxes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EQs-qx-UuI" userLabel="CheckBox3 Label">
-                                                    <rect key="frame" x="23" y="7" width="208" height="20.5"/>
+                                                <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Above Checkboxes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EQs-qx-UuI" userLabel="CheckBox3 Label">
+                                                    <rect key="frame" x="23" y="7" width="203" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.h
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.h
@@ -10,6 +10,4 @@
 
 @interface MLCheckBox : MLBooleanWidget
 
-- (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated;
-
 @end

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.h
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.h
@@ -10,4 +10,6 @@
 
 @interface MLCheckBox : MLBooleanWidget
 
+- (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated;
+
 @end

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -93,7 +93,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)setOnBooleanWidgetAnimated:(BOOL)animated
 {
-	if (self.isBooleanWidgetOn) {
+	if (self.isBooleanWidgetOn || !self.userInteractionEnabled) {
 		return;
 	}
 
@@ -189,6 +189,10 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)setOffBooleanWidgetAnimated:(BOOL)animated
 {
+    if (!self.userInteractionEnabled) {
+        return;
+    }
+    
 	[self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] Animated:animated];
 	[self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] FromOpacity:1 ToOpacity:0 Animated:animated];
 }

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -275,12 +275,12 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (UIColor *)enabledOffColor
 {
-	return [UIColor ml_meli_mid_grey];
+	return [UIColor ml_meli_grey];
 }
 
 - (UIColor *)disabledColor
 {
-	return [UIColor ml_meli_light_grey];
+	return [UIColor ml_meli_mid_grey];
 }
 
 @end

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -33,233 +33,231 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)commonInit
 {
-    [super commonInit];
-    
-    // create external Layer
-    [self.checkBoxExternalLayer removeFromSuperlayer];
-    self.checkBoxExternalLayer = [CAShapeLayer layer];
-    [self.layer addSublayer:self.checkBoxExternalLayer];
-    
-    // create external Layer
-    [self.checkBoxInternalLayer removeFromSuperlayer];
-    self.checkBoxInternalLayer = [CAShapeLayer layer];
-    [self.layer addSublayer:self.checkBoxInternalLayer];
-    
-    // create tick layer
-    self.checkBoxTickLayer = [CAShapeLayer layer];
-    [self.layer addSublayer:self.checkBoxTickLayer];
+	[super commonInit];
+
+	// create external Layer
+	[self.checkBoxExternalLayer removeFromSuperlayer];
+	self.checkBoxExternalLayer = [CAShapeLayer layer];
+	[self.layer addSublayer:self.checkBoxExternalLayer];
+
+	// create external Layer
+	[self.checkBoxInternalLayer removeFromSuperlayer];
+	self.checkBoxInternalLayer = [CAShapeLayer layer];
+	[self.layer addSublayer:self.checkBoxInternalLayer];
+
+	// create tick layer
+	self.checkBoxTickLayer = [CAShapeLayer layer];
+	[self.layer addSublayer:self.checkBoxTickLayer];
 }
 
 #pragma mark - Navigation
 - (void)layoutSubviews
 {
-    [super layoutSubviews];
-    
-    self.checkBoxTickLayer.frame = self.bounds;
-    self.checkBoxExternalLayer.frame = self.bounds;
-    self.checkBoxInternalLayer.frame = self.bounds;
+	[super layoutSubviews];
+
+	self.checkBoxTickLayer.frame = self.bounds;
+	self.checkBoxExternalLayer.frame = self.bounds;
+	self.checkBoxInternalLayer.frame = self.bounds;
 }
 
 #pragma mark - Public Methods
 - (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
 {
-    if (self.userInteractionEnabled == enabled) {
-        return;
-    }
-    
-    self.userInteractionEnabled = enabled;
-    if (enabled) {
-        if (self.isBooleanWidgetOn) {
-            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
-            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:1 ToOpacity:1 Animated:animated];
-            [self fillCheckBoxTickAnimated:animated];
-        } else {
-            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] Animated:animated];
-            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
-        }
-    } else {
-        if (self.isBooleanWidgetOn) {
-            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
-            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:1 ToOpacity:1 Animated:animated];
-            [self fillCheckBoxTickAnimated:animated];
-        } else {
-            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
-            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
-        }
-    }
+	if (self.userInteractionEnabled == enabled) {
+		return;
+	}
+
+	self.userInteractionEnabled = enabled;
+	if (enabled) {
+		if (self.isBooleanWidgetOn) {
+			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:1 ToOpacity:1 Animated:animated];
+			[self fillCheckBoxTickAnimated:animated];
+		} else {
+			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
+		}
+	} else {
+		if (self.isBooleanWidgetOn) {
+			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:1 ToOpacity:1 Animated:animated];
+			[self fillCheckBoxTickAnimated:animated];
+		} else {
+			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
+		}
+	}
 }
 
 #pragma mark - Animation
 
 - (void)setOnBooleanWidgetAnimated:(BOOL)animated
 {
-    if (self.isBooleanWidgetOn) {
-        return;
-    }
-    
-    [self fillCheckBoxExternalAnimated:animated];
-    [self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:0 ToOpacity:1 Animated:animated];
-    [self fillCheckBoxTickAnimated:animated];
+	if (self.isBooleanWidgetOn) {
+		return;
+	}
+
+	[self fillCheckBoxExternalAnimated:animated];
+	[self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:0 ToOpacity:1 Animated:animated];
+	[self fillCheckBoxTickAnimated:animated];
 }
 
 - (void)fillCheckBoxExternalFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor Animated:(BOOL)animated
 {
-    // Set circle layer bounds
-    self.checkBoxExternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-    
-    // Set circle layer path
-    UIBezierPath *externalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-    self.checkBoxExternalLayer.path = externalFrame.CGPath;
-    
-    self.checkBoxExternalLayer.fillColor = [UIColor clearColor].CGColor;
-    self.checkBoxExternalLayer.lineWidth = kMLCheckBoxExternalLineWidth;
-    
-    // Color animation
-    CABasicAnimation *colorFillAnimation = [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration ];
-    
-    [self.checkBoxExternalLayer addAnimation:colorFillAnimation forKey:@"animateFill"];
-    
-    self.checkBoxExternalLayer.strokeColor = toColor.CGColor;
+	// Set circle layer bounds
+	self.checkBoxExternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
+
+	// Set circle layer path
+	UIBezierPath *externalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
+	self.checkBoxExternalLayer.path = externalFrame.CGPath;
+
+	self.checkBoxExternalLayer.fillColor = [UIColor clearColor].CGColor;
+	self.checkBoxExternalLayer.lineWidth = kMLCheckBoxExternalLineWidth;
+
+	// Color animation
+	CABasicAnimation *colorFillAnimation = [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration];
+
+	[self.checkBoxExternalLayer addAnimation:colorFillAnimation forKey:@"animateFill"];
+
+	self.checkBoxExternalLayer.strokeColor = toColor.CGColor;
 }
 
 - (void)fillCheckBoxExternalAnimated:(BOOL)animated
 {
-    [self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
+	[self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
 }
 
 - (void)fillCheckBoxInternalFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor FromOpacity:(float)fromOpacity ToOpacity:(float)toOpacity Animated:(BOOL)animated
 {
-    // Set circle layer bounds
-    self.checkBoxInternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-    
-    // Set circle layer path
-    UIBezierPath *internalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-    self.checkBoxInternalLayer.path = internalFrame.CGPath;
-    
-    
-    self.checkBoxInternalLayer.fillColor = toOpacity == 0 ? [UIColor clearColor].CGColor : toColor.CGColor;
-    float lineWidth = kMLCheckBoxExternalLineWidth;
-    
-    self.checkBoxInternalLayer.lineWidth = lineWidth;
-    
-    // Opacity animation
-    CABasicAnimation *opacityFillAnimation = [self createOpacityFillAnimationFromValue:fromOpacity ToValue:toOpacity];
-    
-    // Color animation
-    CABasicAnimation *colorFillAnimation = [self createColorFillAnimationFromColor:fromColor ToColor:toColor];
-    
-    // Compaund animation
-    CAAnimationGroup *fillAnimation = [CAAnimationGroup animation];
-    fillAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
-    [fillAnimation setAnimations:[NSArray arrayWithObjects:colorFillAnimation, opacityFillAnimation, nil]];
-    
-    [self.checkBoxInternalLayer addAnimation:fillAnimation forKey:@"animateFill"];
-    
-    self.checkBoxInternalLayer.strokeColor = toColor.CGColor;
+	// Set circle layer bounds
+	self.checkBoxInternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
+
+	// Set circle layer path
+	UIBezierPath *internalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
+	self.checkBoxInternalLayer.path = internalFrame.CGPath;
+
+	self.checkBoxInternalLayer.fillColor = toOpacity == 0 ? [UIColor clearColor].CGColor : toColor.CGColor;
+	float lineWidth = kMLCheckBoxExternalLineWidth;
+
+	self.checkBoxInternalLayer.lineWidth = lineWidth;
+
+	// Opacity animation
+	CABasicAnimation *opacityFillAnimation = [self createOpacityFillAnimationFromValue:fromOpacity ToValue:toOpacity];
+
+	// Color animation
+	CABasicAnimation *colorFillAnimation = [self createColorFillAnimationFromColor:fromColor ToColor:toColor];
+
+	// Compaund animation
+	CAAnimationGroup *fillAnimation = [CAAnimationGroup animation];
+	fillAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
+	[fillAnimation setAnimations:[NSArray arrayWithObjects:colorFillAnimation, opacityFillAnimation, nil]];
+
+	[self.checkBoxInternalLayer addAnimation:fillAnimation forKey:@"animateFill"];
+
+	self.checkBoxInternalLayer.strokeColor = toColor.CGColor;
 }
 
 - (void)fillCheckBoxTickAnimated:(BOOL)animated
 {
-    // Set circle layer bounds
-    self.checkBoxTickLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-    
-    // Set circle layer path
-    UIBezierPath *tickPath = [UIBezierPath bezierPath];
-    
-    [tickPath moveToPoint:[self tickLeftPointInRect:self.bounds]];
-    [tickPath addLineToPoint:[self tickBotomPointInRect:self.bounds]];
-    [tickPath addLineToPoint:[self tickRightPointInRect:self.bounds]];
-    
-    self.checkBoxTickLayer.path = tickPath.CGPath;
-    
-    self.checkBoxTickLayer.strokeColor = [UIColor ml_meli_white].CGColor;
-    self.checkBoxTickLayer.fillColor = [UIColor clearColor].CGColor;
-    float lineWidth = kMLCheckBoxTickLineWidth;
-    
-    self.checkBoxTickLayer.lineWidth = lineWidth;
-    
-    // Color animation
-    CABasicAnimation *pathTickAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-    pathTickAnimation.fromValue = @0.0;
-    pathTickAnimation.toValue = @1.0;
-    pathTickAnimation.fillMode = kCAFillModeForwards;
-    pathTickAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
-    
-    [self.checkBoxTickLayer addAnimation:pathTickAnimation forKey:@"animateFillTick"];
+	// Set circle layer bounds
+	self.checkBoxTickLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
+
+	// Set circle layer path
+	UIBezierPath *tickPath = [UIBezierPath bezierPath];
+
+	[tickPath moveToPoint:[self tickLeftPointInRect:self.bounds]];
+	[tickPath addLineToPoint:[self tickBotomPointInRect:self.bounds]];
+	[tickPath addLineToPoint:[self tickRightPointInRect:self.bounds]];
+
+	self.checkBoxTickLayer.path = tickPath.CGPath;
+
+	self.checkBoxTickLayer.strokeColor = [UIColor ml_meli_white].CGColor;
+	self.checkBoxTickLayer.fillColor = [UIColor clearColor].CGColor;
+	float lineWidth = kMLCheckBoxTickLineWidth;
+
+	self.checkBoxTickLayer.lineWidth = lineWidth;
+
+	// Color animation
+	CABasicAnimation *pathTickAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
+	pathTickAnimation.fromValue = @0.0;
+	pathTickAnimation.toValue = @1.0;
+	pathTickAnimation.fillMode = kCAFillModeForwards;
+	pathTickAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
+
+	[self.checkBoxTickLayer addAnimation:pathTickAnimation forKey:@"animateFillTick"];
 }
 
 - (void)setOffBooleanWidgetAnimated:(BOOL)animated
 {
-    [self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] Animated:animated];
-    [self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] FromOpacity:1 ToOpacity:0 Animated:animated];
+	[self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] Animated:animated];
+	[self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] FromOpacity:1 ToOpacity:0 Animated:animated];
 }
 
 #pragma mark - Tick Positions
 - (CGPoint)tickLeftPointInRect:(CGRect)rect
 {
-    CGFloat x = rect.size.width * (2.5 / 15.0);
-    CGFloat y = rect.size.height / 2.0;
-    
-    return CGPointMake(x, y);
+	CGFloat x = rect.size.width * (2.5 / 15.0);
+	CGFloat y = rect.size.height / 2.0;
+
+	return CGPointMake(x, y);
 }
 
 - (CGPoint)tickBotomPointInRect:(CGRect)rect
 {
-    CGFloat x = rect.size.width * (1.0 / 3.0);
-    CGFloat y = rect.size.height * (2.0 / 3.0);
-    
-    return CGPointMake(x, y);
+	CGFloat x = rect.size.width * (1.0 / 3.0);
+	CGFloat y = rect.size.height * (2.0 / 3.0);
+
+	return CGPointMake(x, y);
 }
 
 - (CGPoint)tickRightPointInRect:(CGRect)rect
 {
-    CGFloat x = rect.size.width - (rect.size.width * (2.5 / 15.0));
-    CGFloat y = rect.size.height / 4.0;
-    
-    return CGPointMake(x, y);
+	CGFloat x = rect.size.width - (rect.size.width * (2.5 / 15.0));
+	CGFloat y = rect.size.height / 4.0;
+
+	return CGPointMake(x, y);
 }
 
 - (CABasicAnimation *)createOpacityFillAnimationFromValue:(float)fromValue ToValue:(float)toValue
 {
-    return [self createOpacityFillAnimationFromValue:fromValue ToValue:toValue WithDuration:0 WithFillMode:kCAFillModeForwards];
+	return [self createOpacityFillAnimationFromValue:fromValue ToValue:toValue WithDuration:0 WithFillMode:kCAFillModeForwards];
 }
 
 - (CABasicAnimation *)createOpacityFillAnimationFromValue:(float)fromValue ToValue:(float)toValue WithDuration:(double)duration
 {
-    return [self createOpacityFillAnimationFromValue:fromValue ToValue:toValue WithDuration:duration WithFillMode:kCAFillModeForwards];
+	return [self createOpacityFillAnimationFromValue:fromValue ToValue:toValue WithDuration:duration WithFillMode:kCAFillModeForwards];
 }
 
 - (CABasicAnimation *)createOpacityFillAnimationFromValue:(float)fromValue ToValue:(float)toValue WithDuration:(double)duration WithFillMode:(NSString *)fillMode
 {
-    CABasicAnimation *opacityFillAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
-    opacityFillAnimation.fromValue = [NSNumber numberWithFloat:fromValue];
-    opacityFillAnimation.toValue = [NSNumber numberWithFloat:toValue];
-    opacityFillAnimation.duration = duration;
-    opacityFillAnimation.fillMode = fillMode;
-    
-    return opacityFillAnimation;
+	CABasicAnimation *opacityFillAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+	opacityFillAnimation.fromValue = [NSNumber numberWithFloat:fromValue];
+	opacityFillAnimation.toValue = [NSNumber numberWithFloat:toValue];
+	opacityFillAnimation.duration = duration;
+	opacityFillAnimation.fillMode = fillMode;
+
+	return opacityFillAnimation;
 }
 
-- (CABasicAnimation *)createColorFillAnimationFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor WithDuration: (double)duration
+- (CABasicAnimation *)createColorFillAnimationFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor WithDuration:(double)duration
 {
-    return [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:duration WithFillMode:kCAFillModeForwards];
+	return [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:duration WithFillMode:kCAFillModeForwards];
 }
 
 - (CABasicAnimation *)createColorFillAnimationFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor
 {
-    return [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:0 WithFillMode:kCAFillModeForwards];
+	return [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:0 WithFillMode:kCAFillModeForwards];
 }
 
 - (CABasicAnimation *)createColorFillAnimationFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor WithDuration:(double)duration WithFillMode:(NSString *)fillMode
 {
-    CABasicAnimation *colorFillAnimation = [CABasicAnimation animationWithKeyPath:@"strokeColor"];
-    colorFillAnimation.fromValue = (id)fromColor.CGColor;
-    colorFillAnimation.toValue = (id)toColor.CGColor;
-    colorFillAnimation.duration = duration;
-    colorFillAnimation.fillMode = fillMode;
-    
-    return colorFillAnimation;
+	CABasicAnimation *colorFillAnimation = [CABasicAnimation animationWithKeyPath:@"strokeColor"];
+	colorFillAnimation.fromValue = (id)fromColor.CGColor;
+	colorFillAnimation.toValue = (id)toColor.CGColor;
+	colorFillAnimation.duration = duration;
+	colorFillAnimation.fillMode = fillMode;
+
+	return colorFillAnimation;
 }
 
 @end
-

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -49,8 +49,8 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 	// create tick layer
 	self.checkBoxTickLayer = [CAShapeLayer layer];
 	[self.layer addSublayer:self.checkBoxTickLayer];
-    
-    self.isEnabled = YES;
+
+	self.isEnabled = YES;
 }
 
 #pragma mark - Navigation
@@ -270,17 +270,17 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 #pragma mark - Color Getter Methods
 - (UIColor *)enabledOnColor
 {
-    return [UIColor ml_meli_blue];
+	return [UIColor ml_meli_blue];
 }
 
 - (UIColor *)enabledOffColor
 {
-    return [UIColor ml_meli_mid_grey];
+	return [UIColor ml_meli_mid_grey];
 }
 
 - (UIColor *)disabledColor
 {
-    return [UIColor ml_meli_light_grey];
+	return [UIColor ml_meli_light_grey];
 }
 
 @end

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -73,21 +73,21 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 	self.isEnabled = enabled;
 	if (enabled) {
 		if (self.isBooleanWidgetOn) {
-			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
-			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:1 ToOpacity:1 Animated:animated];
+			[self fillCheckBoxExternalFromColor:[self disabledColor] ToColor:[self enabledOnColor] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[self disabledColor] ToColor:[self enabledOnColor] FromOpacity:1 ToOpacity:1 Animated:animated];
 			[self fillCheckBoxTickAnimated:animated];
 		} else {
-			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] Animated:animated];
-			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
+			[self fillCheckBoxExternalFromColor:[self disabledColor] ToColor:[self enabledOffColor] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[self disabledColor] ToColor:[self enabledOffColor] FromOpacity:0 ToOpacity:0 Animated:animated];
 		}
 	} else {
 		if (self.isBooleanWidgetOn) {
-			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
-			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:1 ToOpacity:1 Animated:animated];
+			[self fillCheckBoxExternalFromColor:[self enabledOnColor] ToColor:[self disabledColor] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[self enabledOnColor] ToColor:[self disabledColor] FromOpacity:1 ToOpacity:1 Animated:animated];
 			[self fillCheckBoxTickAnimated:animated];
 		} else {
-			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
-			[self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
+			[self fillCheckBoxExternalFromColor:[self enabledOffColor] ToColor:[self disabledColor] Animated:animated];
+			[self fillCheckBoxInternalFromColor:[self enabledOffColor] ToColor:[self disabledColor] FromOpacity:0 ToOpacity:0 Animated:animated];
 		}
 	}
 }
@@ -101,7 +101,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 	}
 
 	[self fillCheckBoxExternalAnimated:animated];
-	[self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:0 ToOpacity:1 Animated:animated];
+	[self fillCheckBoxInternalFromColor:[self enabledOffColor] ToColor:[self enabledOnColor] FromOpacity:0 ToOpacity:1 Animated:animated];
 	[self fillCheckBoxTickAnimated:animated];
 }
 
@@ -127,7 +127,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)fillCheckBoxExternalAnimated:(BOOL)animated
 {
-	[self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
+	[self fillCheckBoxExternalFromColor:[self enabledOffColor] ToColor:[self enabledOnColor] Animated:animated];
 }
 
 - (void)fillCheckBoxInternalFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor FromOpacity:(float)fromOpacity ToOpacity:(float)toOpacity Animated:(BOOL)animated
@@ -196,8 +196,8 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 		return;
 	}
 
-	[self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] Animated:animated];
-	[self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] FromOpacity:1 ToOpacity:0 Animated:animated];
+	[self fillCheckBoxExternalFromColor:[self enabledOnColor] ToColor:[self enabledOffColor] Animated:animated];
+	[self fillCheckBoxInternalFromColor:[self enabledOnColor] ToColor:[self enabledOffColor] FromOpacity:1 ToOpacity:0 Animated:animated];
 }
 
 #pragma mark - Tick Positions
@@ -265,6 +265,22 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 	colorFillAnimation.fillMode = fillMode;
 
 	return colorFillAnimation;
+}
+
+#pragma mark - Color Getter Methods
+- (UIColor *)enabledOnColor
+{
+    return [UIColor ml_meli_blue];
+}
+
+- (UIColor *)enabledOffColor
+{
+    return [UIColor ml_meli_mid_grey];
+}
+
+- (UIColor *)disabledColor
+{
+    return [UIColor ml_meli_light_grey];
 }
 
 @end

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -24,6 +24,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 @property (nonatomic, strong) CAShapeLayer *checkBoxExternalLayer;
 @property (nonatomic, strong) CAShapeLayer *checkBoxInternalLayer;
 @property (nonatomic, strong) CAShapeLayer *checkBoxTickLayer;
+@property (nonatomic, assign) BOOL isEnabled;
 
 @end
 
@@ -48,6 +49,8 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 	// create tick layer
 	self.checkBoxTickLayer = [CAShapeLayer layer];
 	[self.layer addSublayer:self.checkBoxTickLayer];
+    
+    self.isEnabled = YES;
 }
 
 #pragma mark - Navigation
@@ -63,11 +66,11 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 #pragma mark - Public Methods
 - (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
 {
-	if (self.userInteractionEnabled == enabled) {
+	if (self.isEnabled == enabled) {
 		return;
 	}
 
-	self.userInteractionEnabled = enabled;
+	self.isEnabled = enabled;
 	if (enabled) {
 		if (self.isBooleanWidgetOn) {
 			[self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
@@ -93,7 +96,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)setOnBooleanWidgetAnimated:(BOOL)animated
 {
-	if (self.isBooleanWidgetOn || !self.userInteractionEnabled) {
+	if (self.isBooleanWidgetOn || !self.isEnabled) {
 		return;
 	}
 
@@ -189,7 +192,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)setOffBooleanWidgetAnimated:(BOOL)animated
 {
-	if (!self.userInteractionEnabled) {
+	if (!self.isEnabled) {
 		return;
 	}
 

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -63,7 +63,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 #pragma mark - Public Methods
 - (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
 {
-    [super setEnabled:enabled Animated:animated];
+	[super setEnabled:enabled Animated:animated];
 	if (enabled) {
 		if (self.isBooleanWidgetOn) {
 			[self fillCheckBoxExternalFromColor:[self disabledColor] ToColor:[self enabledOnColor] Animated:animated];

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -24,7 +24,6 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 @property (nonatomic, strong) CAShapeLayer *checkBoxExternalLayer;
 @property (nonatomic, strong) CAShapeLayer *checkBoxInternalLayer;
 @property (nonatomic, strong) CAShapeLayer *checkBoxTickLayer;
-@property (nonatomic, assign) BOOL isEnabled;
 
 @end
 
@@ -49,8 +48,6 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 	// create tick layer
 	self.checkBoxTickLayer = [CAShapeLayer layer];
 	[self.layer addSublayer:self.checkBoxTickLayer];
-
-	self.isEnabled = YES;
 }
 
 #pragma mark - Navigation
@@ -66,16 +63,11 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 #pragma mark - Public Methods
 - (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
 {
-	if (self.isEnabled == enabled) {
-		return;
-	}
-
-	self.isEnabled = enabled;
+    [super setEnabled:enabled Animated:animated];
 	if (enabled) {
 		if (self.isBooleanWidgetOn) {
 			[self fillCheckBoxExternalFromColor:[self disabledColor] ToColor:[self enabledOnColor] Animated:animated];
 			[self fillCheckBoxInternalFromColor:[self disabledColor] ToColor:[self enabledOnColor] FromOpacity:1 ToOpacity:1 Animated:animated];
-			[self fillCheckBoxTickAnimated:animated];
 		} else {
 			[self fillCheckBoxExternalFromColor:[self disabledColor] ToColor:[self enabledOffColor] Animated:animated];
 			[self fillCheckBoxInternalFromColor:[self disabledColor] ToColor:[self enabledOffColor] FromOpacity:0 ToOpacity:0 Animated:animated];
@@ -84,7 +76,6 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 		if (self.isBooleanWidgetOn) {
 			[self fillCheckBoxExternalFromColor:[self enabledOnColor] ToColor:[self disabledColor] Animated:animated];
 			[self fillCheckBoxInternalFromColor:[self enabledOnColor] ToColor:[self disabledColor] FromOpacity:1 ToOpacity:1 Animated:animated];
-			[self fillCheckBoxTickAnimated:animated];
 		} else {
 			[self fillCheckBoxExternalFromColor:[self enabledOffColor] ToColor:[self disabledColor] Animated:animated];
 			[self fillCheckBoxInternalFromColor:[self enabledOffColor] ToColor:[self disabledColor] FromOpacity:0 ToOpacity:0 Animated:animated];

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -60,6 +60,11 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
     self.checkBoxInternalLayer.frame = self.bounds;
 }
 
+#pragma mark - Public Methods
+- (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
+{
+}
+
 #pragma mark - Animation
 
 - (void)setOnBooleanWidgetAnimated:(BOOL)animated

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -33,245 +33,204 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)commonInit
 {
-	[super commonInit];
-
-	// create external Layer
-	[self.checkBoxExternalLayer removeFromSuperlayer];
-	self.checkBoxExternalLayer = [CAShapeLayer layer];
-	[self.layer addSublayer:self.checkBoxExternalLayer];
-
-	// create external Layer
-	[self.checkBoxInternalLayer removeFromSuperlayer];
-	self.checkBoxInternalLayer = [CAShapeLayer layer];
-	[self.layer addSublayer:self.checkBoxInternalLayer];
-
-	// create tick layer
-	self.checkBoxTickLayer = [CAShapeLayer layer];
-	[self.layer addSublayer:self.checkBoxTickLayer];
+    [super commonInit];
+    
+    // create external Layer
+    [self.checkBoxExternalLayer removeFromSuperlayer];
+    self.checkBoxExternalLayer = [CAShapeLayer layer];
+    [self.layer addSublayer:self.checkBoxExternalLayer];
+    
+    // create external Layer
+    [self.checkBoxInternalLayer removeFromSuperlayer];
+    self.checkBoxInternalLayer = [CAShapeLayer layer];
+    [self.layer addSublayer:self.checkBoxInternalLayer];
+    
+    // create tick layer
+    self.checkBoxTickLayer = [CAShapeLayer layer];
+    [self.layer addSublayer:self.checkBoxTickLayer];
 }
 
 #pragma mark - Navigation
 - (void)layoutSubviews
 {
-	[super layoutSubviews];
-
-	self.checkBoxTickLayer.frame = self.bounds;
-	self.checkBoxExternalLayer.frame = self.bounds;
-	self.checkBoxInternalLayer.frame = self.bounds;
+    [super layoutSubviews];
+    
+    self.checkBoxTickLayer.frame = self.bounds;
+    self.checkBoxExternalLayer.frame = self.bounds;
+    self.checkBoxInternalLayer.frame = self.bounds;
 }
 
 #pragma mark - Animation
+
 - (void)setOnBooleanWidgetAnimated:(BOOL)animated
 {
-	if (self.isBooleanWidgetOn) {
-		return;
-	}
+    if (self.isBooleanWidgetOn) {
+        return;
+    }
+    
+    [self fillCheckBoxExternalAnimated:animated];
+    [self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:0 ToOpacity:1 Animated:animated];
+    [self fillCheckBoxTickAnimated:animated];
+}
 
-	[self fillCheckBoxExternalAnimated:animated];
-	[self fillCheckBoxInternalAnimated:animated];
-	[self fillCheckBoxTickAnimated:animated];
+- (void)fillCheckBoxExternalFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor Animated:(BOOL)animated
+{
+    // Set circle layer bounds
+    self.checkBoxExternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
+    
+    // Set circle layer path
+    UIBezierPath *externalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
+    self.checkBoxExternalLayer.path = externalFrame.CGPath;
+    
+    self.checkBoxExternalLayer.fillColor = [UIColor clearColor].CGColor;
+    self.checkBoxExternalLayer.lineWidth = kMLCheckBoxExternalLineWidth;
+    
+    // Color animation
+    CABasicAnimation *colorFillAnimation = [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration ];
+    
+    [self.checkBoxExternalLayer addAnimation:colorFillAnimation forKey:@"animateFill"];
+    
+    self.checkBoxExternalLayer.strokeColor = toColor.CGColor;
 }
 
 - (void)fillCheckBoxExternalAnimated:(BOOL)animated
 {
-	// Set circle layer bounds
-	self.checkBoxExternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-
-	// Set circle layer path
-	UIBezierPath *externalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-	self.checkBoxExternalLayer.path = externalFrame.CGPath;
-
-	self.checkBoxExternalLayer.fillColor = [UIColor clearColor].CGColor;
-	float lineWidth = kMLCheckBoxExternalLineWidth;
-
-	self.checkBoxExternalLayer.lineWidth = lineWidth;
-
-	// Color animation
-	CABasicAnimation *colorFillAnimation = [CABasicAnimation animationWithKeyPath:@"strokeColor"];
-	colorFillAnimation.beginTime = 0;
-	colorFillAnimation.fromValue = (id)[UIColor ml_meli_grey].CGColor;
-	colorFillAnimation.toValue = (id)[UIColor ml_meli_blue].CGColor;
-	colorFillAnimation.fillMode = kCAFillModeForwards;
-	colorFillAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
-
-	[self.checkBoxExternalLayer addAnimation:colorFillAnimation forKey:@"animateFill"];
-
-	self.checkBoxExternalLayer.strokeColor = [UIColor ml_meli_blue].CGColor;
+    [self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
 }
 
-- (void)fillCheckBoxInternalAnimated:(BOOL)animated
+- (void)fillCheckBoxInternalFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor FromOpacity:(float)fromOpacity ToOpacity:(float)toOpacity Animated:(BOOL)animated
 {
-	// Set circle layer bounds
-	self.checkBoxInternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-
-	// Set circle layer path
-	UIBezierPath *externalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-	self.checkBoxInternalLayer.path = externalFrame.CGPath;
-
-	UIBezierPath *internalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-
-	self.checkBoxInternalLayer.fillColor = [UIColor ml_meli_blue].CGColor;
-	float lineWidth = kMLCheckBoxExternalLineWidth;
-
-	self.checkBoxInternalLayer.lineWidth = lineWidth;
-
-	// Opacity animation
-	CABasicAnimation *opacityFillAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
-	opacityFillAnimation.beginTime = 0;
-	opacityFillAnimation.fromValue = @0;
-	opacityFillAnimation.toValue = @1;
-	opacityFillAnimation.fillMode = kCAFillModeForwards;
-
-	// Color animation
-	CABasicAnimation *colorFillAnimation = [CABasicAnimation animationWithKeyPath:@"strokeColor"];
-	colorFillAnimation.beginTime = 0;
-	colorFillAnimation.fromValue = (id)[UIColor ml_meli_grey].CGColor;
-	colorFillAnimation.toValue = (id)[UIColor ml_meli_blue].CGColor;
-	colorFillAnimation.fillMode = kCAFillModeForwards;
-
-	// Compaund animation
-	CAAnimationGroup *fillAnimation = [CAAnimationGroup animation];
-	fillAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
-	[fillAnimation setAnimations:[NSArray arrayWithObjects:colorFillAnimation, opacityFillAnimation, nil]];
-
-	[self.checkBoxInternalLayer addAnimation:fillAnimation forKey:@"animateFill"];
-
-	self.checkBoxInternalLayer.strokeColor = [UIColor ml_meli_blue].CGColor;
-	self.checkBoxInternalLayer.path = internalFrame.CGPath;
-	self.checkBoxInternalLayer.opacity = 1;
+    // Set circle layer bounds
+    self.checkBoxInternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
+    
+    // Set circle layer path
+    UIBezierPath *internalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
+    self.checkBoxInternalLayer.path = internalFrame.CGPath;
+    
+    
+    self.checkBoxInternalLayer.fillColor = toOpacity == 0 ? [UIColor clearColor].CGColor : toColor.CGColor;
+    float lineWidth = kMLCheckBoxExternalLineWidth;
+    
+    self.checkBoxInternalLayer.lineWidth = lineWidth;
+    
+    // Opacity animation
+    CABasicAnimation *opacityFillAnimation = [self createOpacityFillAnimationFromValue:fromOpacity ToValue:toOpacity];
+    
+    // Color animation
+    CABasicAnimation *colorFillAnimation = [self createColorFillAnimationFromColor:fromColor ToColor:toColor];
+    
+    // Compaund animation
+    CAAnimationGroup *fillAnimation = [CAAnimationGroup animation];
+    fillAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
+    [fillAnimation setAnimations:[NSArray arrayWithObjects:colorFillAnimation, opacityFillAnimation, nil]];
+    
+    [self.checkBoxInternalLayer addAnimation:fillAnimation forKey:@"animateFill"];
+    
+    self.checkBoxInternalLayer.strokeColor = toColor.CGColor;
 }
 
 - (void)fillCheckBoxTickAnimated:(BOOL)animated
 {
-	// Set circle layer bounds
-	self.checkBoxTickLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-
-	// Set circle layer path
-	UIBezierPath *tickPath = [UIBezierPath bezierPath];
-
-	[tickPath moveToPoint:[self tickLeftPointInRect:self.bounds]];
-	[tickPath addLineToPoint:[self tickBotomPointInRect:self.bounds]];
-	[tickPath addLineToPoint:[self tickRightPointInRect:self.bounds]];
-
-	self.checkBoxTickLayer.path = tickPath.CGPath;
-
-	self.checkBoxTickLayer.strokeColor = [UIColor ml_meli_white].CGColor;
-	self.checkBoxTickLayer.fillColor = [UIColor clearColor].CGColor;
-	float lineWidth = kMLCheckBoxTickLineWidth;
-
-	self.checkBoxTickLayer.lineWidth = lineWidth;
-
-	// Color animation
-	CABasicAnimation *pathTickAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
-	pathTickAnimation.beginTime = 0;
-	pathTickAnimation.fromValue = @0.0;
-	pathTickAnimation.toValue = @1.0;
-	pathTickAnimation.fillMode = kCAFillModeForwards;
-	pathTickAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
-
-	[self.checkBoxTickLayer addAnimation:pathTickAnimation forKey:@"animateFillTick"];
+    // Set circle layer bounds
+    self.checkBoxTickLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
+    
+    // Set circle layer path
+    UIBezierPath *tickPath = [UIBezierPath bezierPath];
+    
+    [tickPath moveToPoint:[self tickLeftPointInRect:self.bounds]];
+    [tickPath addLineToPoint:[self tickBotomPointInRect:self.bounds]];
+    [tickPath addLineToPoint:[self tickRightPointInRect:self.bounds]];
+    
+    self.checkBoxTickLayer.path = tickPath.CGPath;
+    
+    self.checkBoxTickLayer.strokeColor = [UIColor ml_meli_white].CGColor;
+    self.checkBoxTickLayer.fillColor = [UIColor clearColor].CGColor;
+    float lineWidth = kMLCheckBoxTickLineWidth;
+    
+    self.checkBoxTickLayer.lineWidth = lineWidth;
+    
+    // Color animation
+    CABasicAnimation *pathTickAnimation = [CABasicAnimation animationWithKeyPath:@"strokeEnd"];
+    pathTickAnimation.fromValue = @0.0;
+    pathTickAnimation.toValue = @1.0;
+    pathTickAnimation.fillMode = kCAFillModeForwards;
+    pathTickAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
+    
+    [self.checkBoxTickLayer addAnimation:pathTickAnimation forKey:@"animateFillTick"];
 }
 
 - (void)setOffBooleanWidgetAnimated:(BOOL)animated
 {
-	[self clearCheckBoxExternalAnimated:animated];
-	[self clearCheckBoxInternalAnimated:animated];
-}
-
-- (void)clearCheckBoxExternalAnimated:(BOOL)animated
-{
-	// Set circle layer bounds
-	self.checkBoxExternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-
-	// Set circle layer path
-	UIBezierPath *externalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-
-	self.checkBoxExternalLayer.path = externalFrame.CGPath;
-
-	self.checkBoxExternalLayer.fillColor = [UIColor clearColor].CGColor;
-	float lineWidth = kMLCheckBoxExternalLineWidth;
-
-	self.checkBoxExternalLayer.lineWidth = lineWidth;
-
-	// Color animation
-	CABasicAnimation *colorFillAnimation = [CABasicAnimation animationWithKeyPath:@"strokeColor"];
-	colorFillAnimation.beginTime = 0;
-	colorFillAnimation.fromValue = (id)[UIColor ml_meli_blue].CGColor;
-	colorFillAnimation.toValue = (id)[UIColor ml_meli_grey].CGColor;
-	colorFillAnimation.fillMode = kCAFillModeForwards;
-	colorFillAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
-
-	[self.checkBoxExternalLayer addAnimation:colorFillAnimation forKey:@"animateFill"];
-
-	self.checkBoxExternalLayer.strokeColor = [UIColor ml_meli_grey].CGColor;
-}
-
-- (void)clearCheckBoxInternalAnimated:(BOOL)animated
-{
-	// Set circle layer bounds
-	self.checkBoxInternalLayer.bounds = CGRectMake(0, 0, CGRectGetHeight(self.frame), CGRectGetWidth(self.frame));
-
-	// Set circle layer path
-	UIBezierPath *externalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-
-	UIBezierPath *internalFrame = [UIBezierPath bezierPathWithRoundedRect:self.checkBoxExternalLayer.bounds cornerRadius:kMLCheckBoxExternalCornerRadius];
-	[internalFrame fill];
-
-	self.checkBoxInternalLayer.path = internalFrame.CGPath;
-
-	self.checkBoxInternalLayer.fillColor = [UIColor clearColor].CGColor;
-	float lineWidth = kMLCheckBoxExternalLineWidth;
-	self.checkBoxInternalLayer.lineWidth = lineWidth;
-
-	// Opacity animation
-	CABasicAnimation *opacityClearAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
-	opacityClearAnimation.beginTime = 0;
-	opacityClearAnimation.fromValue = @1;
-	opacityClearAnimation.toValue = @0;
-	opacityClearAnimation.fillMode = kCAFillModeForwards;
-
-	// Color animation
-	CABasicAnimation *colorClearAnimation = [CABasicAnimation animationWithKeyPath:@"strokeColor"];
-	colorClearAnimation.beginTime = 0;
-	colorClearAnimation.fromValue = (id)[UIColor ml_meli_blue].CGColor;
-	colorClearAnimation.toValue = (id)[UIColor ml_meli_grey].CGColor;
-	colorClearAnimation.fillMode = kCAFillModeForwards;
-
-	// Compaund animation
-	CAAnimationGroup *clearAnimation = [CAAnimationGroup animation];
-	clearAnimation.duration = animated ? kMLCheckBoxAnimationDuration : kMLCheckBoxNotAnimationDuration;
-	[clearAnimation setAnimations:[NSArray arrayWithObjects:colorClearAnimation, opacityClearAnimation, nil]];
-
-	[self.checkBoxInternalLayer addAnimation:clearAnimation forKey:@"animateClear"];
-
-	self.checkBoxInternalLayer.strokeColor = [UIColor ml_meli_grey].CGColor;
-	self.checkBoxInternalLayer.path = externalFrame.CGPath;
-	self.checkBoxInternalLayer.opacity = 0;
+    [self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] Animated:animated];
+    [self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] FromOpacity:1 ToOpacity:0 Animated:animated];
 }
 
 #pragma mark - Tick Positions
 - (CGPoint)tickLeftPointInRect:(CGRect)rect
 {
-	CGFloat x = rect.size.width * (2.5 / 15.0);
-	CGFloat y = rect.size.height / 2.0;
-
-	return CGPointMake(x, y);
+    CGFloat x = rect.size.width * (2.5 / 15.0);
+    CGFloat y = rect.size.height / 2.0;
+    
+    return CGPointMake(x, y);
 }
 
 - (CGPoint)tickBotomPointInRect:(CGRect)rect
 {
-	CGFloat x = rect.size.width * (1.0 / 3.0);
-	CGFloat y = rect.size.height * (2.0 / 3.0);
-
-	return CGPointMake(x, y);
+    CGFloat x = rect.size.width * (1.0 / 3.0);
+    CGFloat y = rect.size.height * (2.0 / 3.0);
+    
+    return CGPointMake(x, y);
 }
 
 - (CGPoint)tickRightPointInRect:(CGRect)rect
 {
-	CGFloat x = rect.size.width - (rect.size.width * (2.5 / 15.0));
-	CGFloat y = rect.size.height / 4.0;
+    CGFloat x = rect.size.width - (rect.size.width * (2.5 / 15.0));
+    CGFloat y = rect.size.height / 4.0;
+    
+    return CGPointMake(x, y);
+}
 
-	return CGPointMake(x, y);
+- (CABasicAnimation *)createOpacityFillAnimationFromValue:(float)fromValue ToValue:(float)toValue
+{
+    return [self createOpacityFillAnimationFromValue:fromValue ToValue:toValue WithDuration:0 WithFillMode:kCAFillModeForwards];
+}
+
+- (CABasicAnimation *)createOpacityFillAnimationFromValue:(float)fromValue ToValue:(float)toValue WithDuration:(double)duration
+{
+    return [self createOpacityFillAnimationFromValue:fromValue ToValue:toValue WithDuration:duration WithFillMode:kCAFillModeForwards];
+}
+
+- (CABasicAnimation *)createOpacityFillAnimationFromValue:(float)fromValue ToValue:(float)toValue WithDuration:(double)duration WithFillMode:(NSString *)fillMode
+{
+    CABasicAnimation *opacityFillAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
+    opacityFillAnimation.fromValue = [NSNumber numberWithFloat:fromValue];
+    opacityFillAnimation.toValue = [NSNumber numberWithFloat:toValue];
+    opacityFillAnimation.duration = duration;
+    opacityFillAnimation.fillMode = fillMode;
+    
+    return opacityFillAnimation;
+}
+
+- (CABasicAnimation *)createColorFillAnimationFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor WithDuration: (double)duration
+{
+    return [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:duration WithFillMode:kCAFillModeForwards];
+}
+
+- (CABasicAnimation *)createColorFillAnimationFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor
+{
+    return [self createColorFillAnimationFromColor:fromColor ToColor:toColor WithDuration:0 WithFillMode:kCAFillModeForwards];
+}
+
+- (CABasicAnimation *)createColorFillAnimationFromColor:(UIColor *)fromColor ToColor:(UIColor *)toColor WithDuration:(double)duration WithFillMode:(NSString *)fillMode
+{
+    CABasicAnimation *colorFillAnimation = [CABasicAnimation animationWithKeyPath:@"strokeColor"];
+    colorFillAnimation.fromValue = (id)fromColor.CGColor;
+    colorFillAnimation.toValue = (id)toColor.CGColor;
+    colorFillAnimation.duration = duration;
+    colorFillAnimation.fillMode = fillMode;
+    
+    return colorFillAnimation;
 }
 
 @end
+

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -63,6 +63,30 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 #pragma mark - Public Methods
 - (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
 {
+    if (self.userInteractionEnabled == enabled) {
+        return;
+    }
+    
+    self.userInteractionEnabled = enabled;
+    if (enabled) {
+        if (self.isBooleanWidgetOn) {
+            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] Animated:animated];
+            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_blue] FromOpacity:1 ToOpacity:1 Animated:animated];
+            [self fillCheckBoxTickAnimated:animated];
+        } else {
+            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] Animated:animated];
+            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_mid_grey] ToColor:[UIColor ml_meli_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
+        }
+    } else {
+        if (self.isBooleanWidgetOn) {
+            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
+            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:1 ToOpacity:1 Animated:animated];
+            [self fillCheckBoxTickAnimated:animated];
+        } else {
+            [self fillCheckBoxExternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] Animated:animated];
+            [self fillCheckBoxInternalFromColor:[UIColor ml_meli_grey] ToColor:[UIColor ml_meli_mid_grey] FromOpacity:0 ToOpacity:0 Animated:animated];
+        }
+    }
 }
 
 #pragma mark - Animation

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -189,10 +189,10 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 
 - (void)setOffBooleanWidgetAnimated:(BOOL)animated
 {
-    if (!self.userInteractionEnabled) {
-        return;
-    }
-    
+	if (!self.userInteractionEnabled) {
+		return;
+	}
+
 	[self fillCheckBoxExternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] Animated:animated];
 	[self fillCheckBoxInternalFromColor:[UIColor ml_meli_blue] ToColor:[UIColor ml_meli_grey] FromOpacity:1 ToOpacity:0 Animated:animated];
 }

--- a/LibraryComponents/MLBooleanWidget/classes/MLBooleanWidget.h
+++ b/LibraryComponents/MLBooleanWidget/classes/MLBooleanWidget.h
@@ -71,6 +71,16 @@
  */
 - (BOOL)isOff;
 
+/**
+ *  Returns YES if the Widget is enabled and NO if it is not.
+ */
+- (BOOL)isEnabled;
+
+/**
+ *  Sets the Widget either to enabled or disabled with or without an animation.
+ */
+- (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated;
+
 @end
 
 /**

--- a/LibraryComponents/MLBooleanWidget/classes/MLBooleanWidget.m
+++ b/LibraryComponents/MLBooleanWidget/classes/MLBooleanWidget.m
@@ -7,8 +7,13 @@
 //
 
 #import "MLBooleanWidget.h"
-
 #import "MLBooleanWidget_Protected.h"
+
+@interface MLBooleanWidget()
+
+@property (nonatomic, assign) BOOL enabled;
+
+@end
 
 @implementation MLBooleanWidget
 
@@ -50,12 +55,27 @@
 
 - (void)commonInit
 {
-	// Default radio button state is clear
+	// Default Boolean Widget is Enabled and Off.
+    self.enabled = YES;
 	[self off];
 
 	self.backgroundColor = [UIColor clearColor];
 
 	[self addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(booleanWidgetWasTapped:)]];
+}
+
+- (BOOL)isEnabled
+{
+    return self.enabled;
+}
+
+- (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
+{
+    if (self.enabled == enabled) {
+        return;
+    }
+    
+    self.enabled = enabled;
 }
 
 #pragma mark - Navigation
@@ -88,6 +108,10 @@
 
 - (void)onAnimated:(BOOL)animated
 {
+    if (!self.enabled) {
+        return;
+    }
+    
 	[self setOnBooleanWidgetAnimated:animated];
 	[self setStateOn];
 }
@@ -99,6 +123,10 @@
 
 - (void)offAnimated:(BOOL)animated
 {
+    if (!self.enabled) {
+        return;
+    }
+    
 	[self setStateOff];
 	[self setOffBooleanWidgetAnimated:animated];
 }
@@ -120,6 +148,10 @@
 
 - (void)toggleAnimated:(BOOL)animated
 {
+    if (!self.enabled) {
+        return;
+    }
+    
 	if (self.isBooleanWidgetOn) {
 		[self offAnimated:animated];
 	} else {

--- a/LibraryComponents/MLBooleanWidget/classes/MLBooleanWidget.m
+++ b/LibraryComponents/MLBooleanWidget/classes/MLBooleanWidget.m
@@ -9,7 +9,7 @@
 #import "MLBooleanWidget.h"
 #import "MLBooleanWidget_Protected.h"
 
-@interface MLBooleanWidget()
+@interface MLBooleanWidget ()
 
 @property (nonatomic, assign) BOOL enabled;
 
@@ -56,7 +56,7 @@
 - (void)commonInit
 {
 	// Default Boolean Widget is Enabled and Off.
-    self.enabled = YES;
+	self.enabled = YES;
 	[self off];
 
 	self.backgroundColor = [UIColor clearColor];
@@ -66,16 +66,16 @@
 
 - (BOOL)isEnabled
 {
-    return self.enabled;
+	return self.enabled;
 }
 
 - (void)setEnabled:(BOOL)enabled Animated:(BOOL)animated
 {
-    if (self.enabled == enabled) {
-        return;
-    }
-    
-    self.enabled = enabled;
+	if (self.enabled == enabled) {
+		return;
+	}
+
+	self.enabled = enabled;
 }
 
 #pragma mark - Navigation
@@ -108,10 +108,10 @@
 
 - (void)onAnimated:(BOOL)animated
 {
-    if (!self.enabled) {
-        return;
-    }
-    
+	if (!self.enabled) {
+		return;
+	}
+
 	[self setOnBooleanWidgetAnimated:animated];
 	[self setStateOn];
 }
@@ -123,10 +123,10 @@
 
 - (void)offAnimated:(BOOL)animated
 {
-    if (!self.enabled) {
-        return;
-    }
-    
+	if (!self.enabled) {
+		return;
+	}
+
 	[self setStateOff];
 	[self setOffBooleanWidgetAnimated:animated];
 }
@@ -148,10 +148,10 @@
 
 - (void)toggleAnimated:(BOOL)animated
 {
-    if (!self.enabled) {
-        return;
-    }
-    
+	if (!self.enabled) {
+		return;
+	}
+
 	if (self.isBooleanWidgetOn) {
 		[self offAnimated:animated];
 	} else {

--- a/MLUIUnitTests/MLCheckButton/MLCheckButtonTest.m
+++ b/MLUIUnitTests/MLCheckButton/MLCheckButtonTest.m
@@ -31,7 +31,7 @@
 	MLCheckBox *checkBox = [[MLCheckBox alloc] init];
 
 	XCTAssertEqual([checkBox isOff], YES);
-    XCTAssertTrue([checkBox isEnabled]);
+	XCTAssertTrue([checkBox isEnabled]);
 }
 
 - (void)testFillCheckButton
@@ -46,27 +46,26 @@
 
 - (void)testDisableCheckBox
 {
-    MLCheckBox *enabledCheckBox = [[MLCheckBox alloc] init];
-    MLCheckBox *disabledCheckBox = [[MLCheckBox alloc] init];
-    [disabledCheckBox setEnabled:NO Animated:NO];
-    
-    XCTAssertTrue([enabledCheckBox isEnabled]);
-    XCTAssertFalse([disabledCheckBox isEnabled]);
-    
-    [enabledCheckBox setEnabled:NO Animated:YES];
-    [disabledCheckBox setEnabled:YES Animated:YES];
-    
-    XCTAssertFalse([enabledCheckBox isEnabled]);
-    XCTAssertTrue([disabledCheckBox isEnabled]);
-    
-    [enabledCheckBox setEnabled:YES Animated:NO];
-    
-    XCTAssertTrue([enabledCheckBox isEnabled]);
+	MLCheckBox *enabledCheckBox = [[MLCheckBox alloc] init];
+	MLCheckBox *disabledCheckBox = [[MLCheckBox alloc] init];
+	[disabledCheckBox setEnabled:NO Animated:NO];
+
+	XCTAssertTrue([enabledCheckBox isEnabled]);
+	XCTAssertFalse([disabledCheckBox isEnabled]);
+
+	[enabledCheckBox setEnabled:NO Animated:YES];
+	[disabledCheckBox setEnabled:YES Animated:YES];
+
+	XCTAssertFalse([enabledCheckBox isEnabled]);
+	XCTAssertTrue([disabledCheckBox isEnabled]);
+
+	[enabledCheckBox setEnabled:YES Animated:NO];
+
+	XCTAssertTrue([enabledCheckBox isEnabled]);
 }
 
 - (void)testEnableCheckBox
 {
-    
 }
 
 - (void)testClearRadioButton

--- a/MLUIUnitTests/MLCheckButton/MLCheckButtonTest.m
+++ b/MLUIUnitTests/MLCheckButton/MLCheckButtonTest.m
@@ -54,18 +54,23 @@
 	XCTAssertFalse([disabledCheckBox isEnabled]);
 
 	[enabledCheckBox setEnabled:NO Animated:YES];
-	[disabledCheckBox setEnabled:YES Animated:YES];
+	[disabledCheckBox setEnabled:NO Animated:YES];
 
 	XCTAssertFalse([enabledCheckBox isEnabled]);
-	XCTAssertTrue([disabledCheckBox isEnabled]);
-
-	[enabledCheckBox setEnabled:YES Animated:NO];
-
-	XCTAssertTrue([enabledCheckBox isEnabled]);
+	XCTAssertFalse([disabledCheckBox isEnabled]);
 }
 
 - (void)testEnableCheckBox
 {
+	MLCheckBox *enabledCheckBox = [[MLCheckBox alloc] init];
+	MLCheckBox *disabledCheckBox = [[MLCheckBox alloc] init];
+	[disabledCheckBox setEnabled:NO Animated:NO];
+
+	[enabledCheckBox setEnabled:YES Animated:YES];
+	[disabledCheckBox setEnabled:YES Animated:YES];
+
+	XCTAssertTrue([enabledCheckBox isEnabled]);
+	XCTAssertTrue([disabledCheckBox isEnabled]);
 }
 
 - (void)testClearRadioButton

--- a/MLUIUnitTests/MLCheckButton/MLCheckButtonTest.m
+++ b/MLUIUnitTests/MLCheckButton/MLCheckButtonTest.m
@@ -31,6 +31,7 @@
 	MLCheckBox *checkBox = [[MLCheckBox alloc] init];
 
 	XCTAssertEqual([checkBox isOff], YES);
+    XCTAssertTrue([checkBox isEnabled]);
 }
 
 - (void)testFillCheckButton
@@ -41,6 +42,31 @@
 
 	XCTAssertEqual([checkBox isOn], YES);
 	XCTAssertEqual([checkBox isOff], NO);
+}
+
+- (void)testDisableCheckBox
+{
+    MLCheckBox *enabledCheckBox = [[MLCheckBox alloc] init];
+    MLCheckBox *disabledCheckBox = [[MLCheckBox alloc] init];
+    [disabledCheckBox setEnabled:NO Animated:NO];
+    
+    XCTAssertTrue([enabledCheckBox isEnabled]);
+    XCTAssertFalse([disabledCheckBox isEnabled]);
+    
+    [enabledCheckBox setEnabled:NO Animated:YES];
+    [disabledCheckBox setEnabled:YES Animated:YES];
+    
+    XCTAssertFalse([enabledCheckBox isEnabled]);
+    XCTAssertTrue([disabledCheckBox isEnabled]);
+    
+    [enabledCheckBox setEnabled:YES Animated:NO];
+    
+    XCTAssertTrue([enabledCheckBox isEnabled]);
+}
+
+- (void)testEnableCheckBox
+{
+    
 }
 
 - (void)testClearRadioButton


### PR DESCRIPTION
Se limpió la clase MLCheckBox. Se hizo una unificación inicial de los métodos responsables por las animaciones para disminuir la repetición del código.

Se añadió el método público setEnabled:(BOOL)Animated:(BOOL) a MLBooleanWidget que habilita/deshabilita la interacción del usuario. Se agregó un override en MLCheckBox que además tiñe el checkbox de UIColor.ml_meli_mid_grey manteniéndolo en el estado de seleccionado/no seleccionado.

La función nueva se añadió a pedido de Ayelen Santamaría para Combo Recommendations.

Nuevos estados de CheckBox:

Checked & Disabled: 
![image](https://user-images.githubusercontent.com/35231462/44428460-ca109180-a56a-11e8-9788-a09cb2cfa071.png)
Unchecked & Disabled:
![image](https://user-images.githubusercontent.com/35231462/44461320-c1f63780-a5e6-11e8-81b7-824840366bdc.png)

Efecto de Cambio:
![check](http://g.recordit.co/eFAe7qkVY6.gif)

Se puede ver el funcionamiento de los cambios de estado en la aplicación de prueba en New UI -> Widgets -> CheckBox, RadioButton & Switch

