### PR TITLE
Fix wrong final state when spinner receives show / hide requests fast

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ jobs:
           name: Run tests on iOS 10.3.1
           command: ./scripts/run_tests.sh 10.3.1
       - run:
-          name: Run test on iOS 11.0
-          command: ./scripts/run_tests.sh 11.0
+          name: Run test on iOS 11.2
+          command: ./scripts/run_tests.sh 11.2
       - run:
           name: Run Coverage Report
           command: ./scripts/run_coverage_report.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 default: &defaultJob
   # Set the xcode version this virtual machine will use
   macos:
-    xcode: "9.4.0"
+    xcode: "10.1.0"
   # We need to set this for RVM.
   shell: /bin/bash --login
 # Default workflow will run on all branches except releases

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 default: &defaultJob
   # Set the xcode version this virtual machine will use
   macos:
-    xcode: "9.0"
+    xcode: "9.4.0"
   # We need to set this for RVM.
   shell: /bin/bash --login
 # Default workflow will run on all branches except releases

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,6 +5,8 @@ set -o pipefail
 IOS_VERSION="${1:-10.3.1}"
 IOS_DEVICE="${2:-iPhone 7}"
 
+xcrun instruments -s devices
+
 export XCPRETTY_JSON_FILE_OUTPUT="build/reports/result_$IOS_VERSION.json"
 FORMATTER="xcpretty -f `bundle exec xcpretty-json-formatter`"
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,9 +3,7 @@ set -v
 set -o pipefail
 
 IOS_VERSION="${1:-10.3.1}"
-IOS_DEVICE="${2:-iPhone 7}"
-
-xcrun instruments -s devices
+IOS_DEVICE="${2:-iPhone 6}"
 
 export XCPRETTY_JSON_FILE_OUTPUT="build/reports/result_$IOS_VERSION.json"
 FORMATTER="xcpretty -f `bundle exec xcpretty-json-formatter`"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,7 +3,7 @@ set -v
 set -o pipefail
 
 IOS_VERSION="${1:-10.3.1}"
-IOS_DEVICE="${2:-iPhone 6}"
+IOS_DEVICE="${2:-iPhone 7}"
 
 export XCPRETTY_JSON_FILE_OUTPUT="build/reports/result_$IOS_VERSION.json"
 FORMATTER="xcpretty -f `bundle exec xcpretty-json-formatter`"


### PR DESCRIPTION
The last implementation use two boolean properties to track the next state to apply to spinner,
this path use an enum and reorganize de code so the changes are easy sinchronized when each change is requested fast after another