### PR TITLE
Fix trailing constraint on MLSnackBar for multiline titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Sin Publicar
+### Arreglado
+- `MLSnackbar`: Se corrige el espaciado derecho para snackbars con title multiline cuando no hay button.
+
 # 5.6.0
 ## Arreglado
 - Se cambia el nombre del método creditCardFontOfSize a monospaceFontOfSize

--- a/LibraryComponents/MLSnackBar/classes/MLSnackbar.m
+++ b/LibraryComponents/MLSnackBar/classes/MLSnackbar.m
@@ -52,7 +52,6 @@
 @property (nonatomic, copy) MLSnackbarDismissBlock dismissBlock;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *labelTopConstraint;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *labelButtonSpacing;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *buttonTrailingConstraint;
 @property (nonatomic) MLSnackbarDuration duration;
 @property (nonatomic) BOOL isShowingSnackbar;
 @property (nonatomic) BOOL isAnimating;
@@ -174,13 +173,11 @@ static int const kMLSnackbarLabelButtonSpacing = 24;
 		self.actionButton.hidden = NO;
 		self.labelButtonSpacing.constant = kMLSnackbarLabelButtonSpacing;
 		[self.actionButton setContentCompressionResistancePriority:751 forAxis:UILayoutConstraintAxisHorizontal];
-		self.buttonTrailingConstraint.constant = 24;
 	} else {
 		// si no se recibe título del botón o un bloque de acción, se esconde el botón
 		self.actionButton.hidden = YES;
 		self.labelButtonSpacing.constant = 0;
 		[self.actionButton setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
-		self.buttonTrailingConstraint.constant = 0;
 	}
 	if (dismissGestureEnabled) {
 		self.gesture = [[UIPanGestureRecognizer alloc]initWithTarget:self action:@selector(swipeAnimation:)];

--- a/LibraryComponents/MLSnackBar/classes/MLSnackbar.xib
+++ b/LibraryComponents/MLSnackBar/classes/MLSnackbar.xib
@@ -1,18 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MLSnackbar">
             <connections>
                 <outlet property="actionButton" destination="5Kz-Cv-8rH" id="AKd-M2-NFo"/>
-                <outlet property="buttonTrailingConstraint" destination="Gdg-Sd-lND" id="IGH-9i-caz"/>
                 <outlet property="labelButtonSpacing" destination="q7z-VR-HMC" id="hir-ZI-EnM"/>
                 <outlet property="messageLabel" destination="7qg-RS-ep6" id="Oaa-Y1-p7v"/>
             </connections>


### PR DESCRIPTION
Se corrige un problema en el espaciado derecho de `MLSnackbar` cuando tiene un title con más de una línea y no posee botón. Esta es una corrección sobre el release 5.7.0.

### Antes
<img width="424" alt="Antes" src="https://user-images.githubusercontent.com/45976466/57484231-e5e5d000-727e-11e9-89c3-786e806282f3.png">

### Después
<img width="424" alt="Despues" src="https://user-images.githubusercontent.com/45976466/57484250-eda57480-727e-11e9-8924-d3647e9a0fed.png">
