### PR TITLE
Set generic colors to MLCheckbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Sin Publicar
+### Arreglado
+- `MLCheckBox`: Se corrigen los colores para que muestre los correspondientes a cada plataforma.  
+
 # v5.8.0
 ### Agregado
 - Min characters attribute and delegate for MLTitledSingleLineTextField

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -10,6 +10,7 @@
 
 #import "UIColor+MLColorPalette.h"
 #import "MLBooleanWidget_Protected.h"
+#import "MLStyleSheetManager.h"
 
 static const CGFloat kMLCheckBoxExternalLineWidth = 2;
 static const CGFloat kMLCheckBoxExternalCornerRadius = 1;
@@ -261,17 +262,17 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 #pragma mark - Color Getter Methods
 - (UIColor *)enabledOnColor
 {
-	return [UIColor ml_meli_blue];
+	return [[MLStyleSheetManager styleSheet] primaryColor];
 }
 
 - (UIColor *)enabledOffColor
 {
-	return [UIColor ml_meli_grey];
+	return [[MLStyleSheetManager styleSheet] greyColor];
 }
 
 - (UIColor *)disabledColor
 {
-	return [UIColor ml_meli_mid_grey];
+	return [[MLStyleSheetManager styleSheet] midGreyColor];
 }
 
 @end

--- a/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
+++ b/LibraryComponents/MLBooleanWidget/MLCheckBox/classes/MLCheckBox.m
@@ -262,7 +262,7 @@ static const CGFloat kMLCheckBoxNotAnimationDuration = 0;
 #pragma mark - Color Getter Methods
 - (UIColor *)enabledOnColor
 {
-	return [[MLStyleSheetManager styleSheet] primaryColor];
+	return [[MLStyleSheetManager styleSheet] secondaryColor];
 }
 
 - (UIColor *)enabledOffColor


### PR DESCRIPTION
#Descripción:

### Se modifican los colores del MLCheckbox para que utilice los de ML o MP según corresponda.