### PR TITLE
🛠 Fix `MLTitledMultiLineTextField` ignores delegate

### DIFF
--- a/LibraryComponents/MLTitledMultiLineTextField/classes/MLTitledMultiLineTextField.m
+++ b/LibraryComponents/MLTitledMultiLineTextField/classes/MLTitledMultiLineTextField.m
@@ -285,7 +285,7 @@
 		return NO;
 	}
 	if ([self.delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
-		[self.delegate textField:self shouldChangeCharactersInRange:range replacementString:text];
+		return [self.delegate textField:self shouldChangeCharactersInRange:range replacementString:text];
 	}
 
 	if ([text isEqualToString:@"\n"] &&

--- a/MLUIUnitTests/MLHtml/classes/MLHtmlTest.m
+++ b/MLUIUnitTests/MLHtml/classes/MLHtmlTest.m
@@ -172,7 +172,7 @@ static const CGFloat kBigSmallFontIncrement = 3;
 	[MLHtml overrideAttributesWithTag:tag dictionary:attrs];
 
 	UIFont *targetFont = attrs[NSFontAttributeName];
-	UIFont *expectedFont = [UIFont fontWithName:@".SFUIText-Light" size:0];
+	UIFont *expectedFont = [UIFont fontWithName:@".SFUIText-Light" size:1];
 
 	XCTAssertEqualObjects(targetFont.fontName, expectedFont.fontName);
 	XCTAssertEqual(targetFont.pointSize, expectedFont.pointSize);

--- a/MLUIUnitTests/MLTitledMultiLineTextField/MLTitledMultiLineTextFieldTest.m
+++ b/MLUIUnitTests/MLTitledMultiLineTextField/MLTitledMultiLineTextFieldTest.m
@@ -17,7 +17,8 @@
 
 - (UITextView *)textView;
 - (CGSize)sizeForText:(NSString *)text;
-
+- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text;
+    
 @end
 
 @interface MLTitledMultiLineTextFieldTest : MLTitledSingleLineTextFieldTest
@@ -67,6 +68,42 @@
 
 	XCTAssertNil(textField.textView.font);
 	XCTAssertEqual([textField sizeForText:@""].width, 0);
+}
+    
+- (void)test_shouldRespectWhenDelegate_Accepts {
+    MLTitledMultiLineTextField *textField = [[MLTitledMultiLineTextField alloc] init];
+    
+    NSString *currentText = @"Current Text";
+    textField.text = currentText;
+    
+    NSString *newText = @"New Text";
+    NSRange range = NSMakeRange(0, currentText.length);
+    
+    NSObject <MLTitledTextFieldDelegate> *delegate = OCMProtocolMock(@protocol(MLTitledTextFieldDelegate));
+    [OCMStub([delegate textField:textField shouldChangeCharactersInRange:range replacementString:newText]) andReturnValue:@(YES)];
+    
+    textField.delegate = delegate;
+    BOOL result = [textField textView:textField.textView shouldChangeTextInRange:range replacementText:newText];
+    
+    XCTAssertTrue(result);
+}
+    
+- (void)test_shouldRespectWhenDelegate_Rejects {
+    MLTitledMultiLineTextField *textField = [[MLTitledMultiLineTextField alloc] init];
+    
+    NSString *currentText = @"Current Text";
+    textField.text = currentText;
+    
+    NSString *newText = @"New Text";
+    NSRange range = NSMakeRange(0, currentText.length);
+    
+    NSObject <MLTitledTextFieldDelegate> *delegate = OCMProtocolMock(@protocol(MLTitledTextFieldDelegate));
+    [OCMStub([delegate textField:textField shouldChangeCharactersInRange:range replacementString:newText]) andReturnValue:@(NO)];
+    
+    textField.delegate = delegate;
+    BOOL result = [textField textView:textField.textView shouldChangeTextInRange:range replacementText:newText];
+    
+     XCTAssertFalse(result);
 }
 
 @end


### PR DESCRIPTION
This PR fixes bug when delegate of `MLTitledMultiLineTextField` returns `NO` in method `textField: shouldChangeCharactersInRange: replacementString:`.
`MLTitledMultiLineTextField` just ignores its result:
```obj-c
if ([self.delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString:)]) {
   [self.delegate textField:self shouldChangeCharactersInRange:range replacementString:text];
}
```
| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/1062240/48750578-8a873d80-ec5e-11e8-94ad-8d516f749eaf.gif) | ![after](https://user-images.githubusercontent.com/1062240/48750579-8a873d80-ec5e-11e8-8c64-a4affa4fb625.gif) |
## How to test?
Apply this [patch.diff.txt](https://github.com/mercadolibre/fury_mobile-ios-ui/files/2598008/patch.diff.txt) and repeat steps from gifs above