### PR TITLE
Reduce Spinner Animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v5.17.0 (Sin Publicar)
+# Sin publicar
+### Cambiado
+- 'MLSpinner': Se reduce el tiempo de la animacion de fadeIn/fadeOut a 50ms
+
+# v5.17.0 
 ### Agregado
 - 'MLRadioButton': se corrigen los colores para que muestre los correspondientes a cada plataforma.  
 

--- a/LibraryComponents/MLSpinner/classes/MLSpinner.m
+++ b/LibraryComponents/MLSpinner/classes/MLSpinner.m
@@ -61,7 +61,7 @@ static const CGFloat kMLSpinnerSmallDiameter = 20;
 static const CGFloat kMLSpinnerBigDiameter = 60;
 static const CGFloat kMLSpinnerSmallLineWidth = 2;
 static const CGFloat kMLSpinnerBigLineWidth = 3;
-static const CGFloat kMLSpinnerAppearenceAnimationDuration = 0.3;
+static const CGFloat kMLSpinnerAppearenceAnimationDuration = 0.05;
 
 - (id)init
 {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - MLUI/MLFonts
     - MLUI/StyleSheet
   - MLUI/MLRadioButton (5.15.0):
-    - MLUI/MLColorPalette
+    - MLUI/StyleSheet
   - MLUI/MLSnackBar (5.15.0):
     - MLUI/Helpers
     - MLUI/MLButton
@@ -128,7 +128,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
-  MLUI: 1ae18284852fd5bca802c5fa3b13ba0dbd9a39ac
+  MLUI: 3789652f9289588ec917a04ae98570d1446e05f8
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
 
 PODFILE CHECKSUM: 16cf6a8b64ee27b03ee4560e3c7e16877816581a


### PR DESCRIPTION
### Description

- Se reduce el tiempo de transicion del spinner (fadeIn/fadeOut) con el fin de mejorar la experiencia de los users, puntualmente en webkit se puede visualizar el spinner aun cuando la pagina haya quedado completamente cargada