### PR TITLE
MLButton Accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Sin publicar
 ### Cambiado
 - 'MLSpinner': Se reduce el tiempo de la animacion de fadeIn/fadeOut a 50ms
+- 'MLButton': Se agranda el area del tap cuando mientras se usa herramientas de accessibilidad.
 
 # v5.18.0
 - Fix modal full screen

--- a/LibraryComponents/MLButton/classes/MLButton.m
+++ b/LibraryComponents/MLButton/classes/MLButton.m
@@ -109,11 +109,16 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
 
 	self.backgroundLayer.borderWidth = kMLButtonBorderWidth;
     
-    [self.label setIsAccessibilityElement:NO];
-    [self setAccessibilityTraits:UIAccessibilityTraitButton];
-
+    [self setUpAccessibility];
 	[self setUpWithSize];
 	[self setUpContentView];
+}
+
+- (void)setUpAccessibility
+{
+    [self.label setIsAccessibilityElement:NO];
+    [self setIsAccessibilityElement:YES];
+    [self setAccessibilityTraits:UIAccessibilityTraitButton];
 }
 
 - (void)setUpWithSize

--- a/LibraryComponents/MLButton/classes/MLButton.m
+++ b/LibraryComponents/MLButton/classes/MLButton.m
@@ -108,17 +108,17 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
 	[self.layer addSublayer:self.backgroundLayer];
 
 	self.backgroundLayer.borderWidth = kMLButtonBorderWidth;
-    
-    [self setUpAccessibility];
+
+	[self setUpAccessibility];
 	[self setUpWithSize];
 	[self setUpContentView];
 }
 
 - (void)setUpAccessibility
 {
-    [self.label setIsAccessibilityElement:NO];
-    [self setIsAccessibilityElement:YES];
-    [self setAccessibilityTraits:UIAccessibilityTraitButton];
+	[self.label setIsAccessibilityElement:NO];
+	[self setIsAccessibilityElement:YES];
+	[self setAccessibilityTraits:UIAccessibilityTraitButton];
 }
 
 - (void)setUpWithSize
@@ -164,9 +164,9 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
 	// TitleLabel Constraints
 	[self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-p@priority-[label]|" options:0 metrics:@{@"p" : @0, @"priority" : @999} views:@{@"label" : self.label}]];
 	[self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[label]|" options:0 metrics:0 views:@{@"label" : self.label}]];
-    
-    // This prevent Voice Over read "possible text" before accessibility value
-    [self setLabel:self.label];
+
+	// This prevent Voice Over read "possible text" before accessibility value
+	[self setLabel:self.label];
 }
 
 - (void)setupIconView

--- a/LibraryComponents/MLButton/classes/MLButton.m
+++ b/LibraryComponents/MLButton/classes/MLButton.m
@@ -108,6 +108,9 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
 	[self.layer addSublayer:self.backgroundLayer];
 
 	self.backgroundLayer.borderWidth = kMLButtonBorderWidth;
+    
+    [self.label setIsAccessibilityElement:NO];
+    [self setAccessibilityTraits:UIAccessibilityTraitButton];
 
 	[self setUpWithSize];
 	[self setUpContentView];
@@ -156,6 +159,9 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
 	// TitleLabel Constraints
 	[self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-p@priority-[label]|" options:0 metrics:@{@"p" : @0, @"priority" : @999} views:@{@"label" : self.label}]];
 	[self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[label]|" options:0 metrics:0 views:@{@"label" : self.label}]];
+    
+    // This prevent Voice Over read "possible text" before accessibility value
+    [self setLabel:self.label];
 }
 
 - (void)setupIconView
@@ -262,6 +268,7 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
 {
     if (!self.isLoading) {
         [super setEnabled:enabled];
+        [self setIsAccessibilityElement:enabled];
         [self updateLookAndFeel];
 	}
 }
@@ -299,6 +306,7 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
     [attributedString addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:NSMakeRange(0, title.length)];
 
     self.label.attributedText = attributedString;
+    [self setAccessibilityValue:self.buttonTitle];
 }
 
 - (void)setConfig:(MLButtonConfig *)config


### PR DESCRIPTION
## Contexto

Desde el equipo de InStore tenemos como poroto de este Q, implementar herramientas de accesibilidad a nuestros flujos.

## Descripción

Con Voice Over activo, el area de tap de MLButton era solo del UILabel que contiene dentro. Lo que hice fue hacer que el label no sea accesible, pero sí lo sea el botón en sí.