### PR TITLE
TextField - Habilitar helperDescription y Contador

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.21.0
+### Cambiado
+- 'MLUITextField': Se agrega el helperDescription con label separado y se coloca el contador al lado derecho.
+
 # v5.20.2
 ### Cambiado
 - 'MLButton': Cuando se hace set button title se configura el accessibilityIdentifier sólo si no fue configurado previamente.

--- a/LibraryComponents/MLTitledSingleLineTextField/assets/MLTitledLineTextField.xib
+++ b/LibraryComponents/MLTitledSingleLineTextField/assets/MLTitledLineTextField.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MLTitledSingleLineTextField">
             <connections>
-                <outlet property="accessoryLabel" destination="mk6-3N-faf" id="Sek-VM-zOU"/>
                 <outlet property="accessoryViewContainer" destination="abO-Fz-yNE" id="EGz-ZP-UoR"/>
+                <outlet property="counterLabel" destination="mk6-3N-faf" id="pHv-K3-iTQ"/>
+                <outlet property="helperDescriptionLabel" destination="wpY-Ad-cHL" id="KwB-br-Fkv"/>
                 <outlet property="lineView" destination="zui-Sp-0jq" id="Gb2-7r-mRM"/>
                 <outlet property="lineViewHeight" destination="sGH-8m-uC3" id="sFq-5c-FiZ"/>
                 <outlet property="placeholderLabel" destination="Opn-WP-FUU" id="Wtr-Dv-WYb"/>
@@ -30,8 +30,14 @@
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mk6-3N-faf">
-                    <rect key="frame" x="0.0" y="91" width="396" height="0.0"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wpY-Ad-cHL" userLabel="HelperDescription">
+                    <rect key="frame" x="0.0" y="91" width="0.0" height="0.0"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mk6-3N-faf" userLabel="Counter">
+                    <rect key="frame" x="396" y="91" width="0.0" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -82,26 +88,29 @@
             </subviews>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="wpY-Ad-cHL" firstAttribute="leading" secondItem="eB9-vN-3kQ" secondAttribute="leading" id="4AV-ZP-roK"/>
                 <constraint firstItem="abO-Fz-yNE" firstAttribute="bottom" secondItem="Ttm-Hz-PLL" secondAttribute="bottom" id="AMk-c3-yQX"/>
                 <constraint firstItem="Ttm-Hz-PLL" firstAttribute="leading" secondItem="eB9-vN-3kQ" secondAttribute="leading" id="COS-bg-Yi0"/>
                 <constraint firstAttribute="trailing" secondItem="mk6-3N-faf" secondAttribute="trailing" id="FpU-Jq-qkJ"/>
-                <constraint firstAttribute="bottom" secondItem="mk6-3N-faf" secondAttribute="bottom" constant="1" id="Ke1-xs-XBF"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mk6-3N-faf" secondAttribute="bottom" constant="1" id="Ke1-xs-XBF"/>
                 <constraint firstAttribute="trailing" secondItem="abO-Fz-yNE" secondAttribute="trailing" id="LdO-Dt-KiE"/>
                 <constraint firstItem="zui-Sp-0jq" firstAttribute="top" secondItem="Ttm-Hz-PLL" secondAttribute="bottom" constant="4" id="QK3-9m-5uO"/>
                 <constraint firstItem="ci8-92-goc" firstAttribute="leading" secondItem="eB9-vN-3kQ" secondAttribute="leading" id="QVd-NZ-R1W"/>
                 <constraint firstItem="mk6-3N-faf" firstAttribute="top" secondItem="zui-Sp-0jq" secondAttribute="bottom" constant="11" id="VP1-gV-kQh"/>
                 <constraint firstAttribute="trailing" secondItem="ci8-92-goc" secondAttribute="trailing" id="bQ1-NM-GCh"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="wpY-Ad-cHL" secondAttribute="bottom" constant="1" id="dro-IZ-O5g"/>
                 <constraint firstItem="abO-Fz-yNE" firstAttribute="trailing" secondItem="zui-Sp-0jq" secondAttribute="trailing" id="du2-DM-xkd"/>
                 <constraint firstItem="Ttm-Hz-PLL" firstAttribute="top" secondItem="ci8-92-goc" secondAttribute="bottom" constant="7" id="hgU-JI-4sj"/>
+                <constraint firstItem="wpY-Ad-cHL" firstAttribute="top" secondItem="zui-Sp-0jq" secondAttribute="bottom" constant="11" id="khe-zS-qJn"/>
                 <constraint firstItem="Ttm-Hz-PLL" firstAttribute="leading" secondItem="zui-Sp-0jq" secondAttribute="leading" id="sin-ZA-P0o"/>
                 <constraint firstItem="abO-Fz-yNE" firstAttribute="top" secondItem="Ttm-Hz-PLL" secondAttribute="top" id="t2w-dC-FIK"/>
-                <constraint firstItem="mk6-3N-faf" firstAttribute="leading" secondItem="eB9-vN-3kQ" secondAttribute="leading" id="vQf-uM-HWf"/>
                 <constraint firstItem="ci8-92-goc" firstAttribute="top" secondItem="eB9-vN-3kQ" secondAttribute="top" constant="2" id="y9q-gt-6oa"/>
+                <constraint firstItem="mk6-3N-faf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="wpY-Ad-cHL" secondAttribute="trailing" id="ybb-cD-muJ"/>
                 <constraint firstItem="abO-Fz-yNE" firstAttribute="leading" secondItem="Ttm-Hz-PLL" secondAttribute="trailing" id="zW5-iU-5p0"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-136.23188405797103" y="-77.678571428571431"/>
+            <point key="canvasLocation" x="-137.59999999999999" y="-78.260869565217391"/>
         </view>
     </objects>
 </document>

--- a/LibraryComponents/MLTitledSingleLineTextField/classes/MLTitledSingleLineTextField.m
+++ b/LibraryComponents/MLTitledSingleLineTextField/classes/MLTitledSingleLineTextField.m
@@ -19,7 +19,8 @@ static const CGFloat kMLTextFieldThickLine = 2;
 @interface MLTitledSingleLineTextField () <UITextFieldDelegate, MLUITextFieldDelegate>
 @property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 @property (weak, nonatomic) IBOutlet UIView *lineView;
-@property (weak, nonatomic) IBOutlet UILabel *accessoryLabel;
+@property (weak, nonatomic) IBOutlet UILabel *helperDescriptionLabel;
+@property (weak, nonatomic) IBOutlet UILabel *counterLabel;
 @property (weak, nonatomic) IBOutlet UILabel *placeholderLabel;
 @property (weak, nonatomic) IBOutlet UIView *textInputContainer;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *lineViewHeight;
@@ -113,7 +114,8 @@ static const CGFloat kMLTextFieldThickLine = 2;
 	self.textField.font = [UIFont ml_regularSystemFontOfSize:kMLFontsSizeMedium];
 	self.titleLabel.font = [UIFont ml_regularSystemFontOfSize:kMLFontsSizeXSmall];
 	self.titleLabel.textColor = MLStyleSheetManager.styleSheet.greyColor;
-	self.accessoryLabel.font = [UIFont ml_regularSystemFontOfSize:kMLFontsSizeXSmall];
+	self.helperDescriptionLabel.font = [UIFont ml_regularSystemFontOfSize:kMLFontsSizeXSmall];
+	self.counterLabel.font = [UIFont ml_regularSystemFontOfSize:kMLFontsSizeXSmall];
 	self.placeholderLabel.font = [UIFont ml_regularSystemFontOfSize:kMLFontsSizeMedium];
 	self.placeholderLabel.textColor = MLStyleSheetManager.styleSheet.greyColor;
 	[self stateDependantStyle];
@@ -124,7 +126,8 @@ static const CGFloat kMLTextFieldThickLine = 2;
 	UIColor *textColor = MLStyleSheetManager.styleSheet.blackColor;
 	UIColor *lineColor = MLStyleSheetManager.styleSheet.midGreyColor;
 	UIColor *labelColor = MLStyleSheetManager.styleSheet.greyColor;
-	UIColor *accessoryLabelColor = MLStyleSheetManager.styleSheet.darkGreyColor;
+	UIColor *helperDescriptionLabelColor = MLStyleSheetManager.styleSheet.darkGreyColor;
+	UIColor *counterLabelColor = MLStyleSheetManager.styleSheet.darkGreyColor;
 	CGFloat lineHeight = kMLTextFieldThinLine;
 
 	switch (self.state) {
@@ -141,7 +144,7 @@ static const CGFloat kMLTextFieldThickLine = 2;
 		}
 
 		case MLTitledTextFieldStateError: {
-			lineColor = accessoryLabelColor = MLStyleSheetManager.styleSheet.errorColor;
+			lineColor = helperDescriptionLabelColor = MLStyleSheetManager.styleSheet.errorColor;
 			lineHeight = kMLTextFieldThickLine;
 			break;
 		}
@@ -165,7 +168,8 @@ static const CGFloat kMLTextFieldThickLine = 2;
 	    weakSelf.lineView.backgroundColor = lineColor;
 	    weakSelf.textField.tintColor = lineColor;
 	    weakSelf.lineViewHeight.constant = lineHeight;
-	    weakSelf.accessoryLabel.textColor = accessoryLabelColor;
+	    weakSelf.helperDescriptionLabel.textColor = helperDescriptionLabelColor;
+	    weakSelf.counterLabel.textColor = counterLabelColor;
 	}];
 }
 
@@ -174,7 +178,7 @@ static const CGFloat kMLTextFieldThickLine = 2;
 	self.placeholderLabel.textAlignment = textAlignment;
 	self.titleLabel.textAlignment = textAlignment;
 	self.textField.textAlignment = textAlignment;
-	self.accessoryLabel.textAlignment = textAlignment;
+	self.helperDescriptionLabel.textAlignment = textAlignment;
 }
 
 - (void)updateCharacterCount
@@ -191,7 +195,7 @@ static const CGFloat kMLTextFieldThickLine = 2;
 		countString = [NSString stringWithFormat:@"%lu", (unsigned long)self.text.length];
 	}
 
-	self.helperDescription = countString;
+	self.counter = countString;
 }
 
 - (void)observeText
@@ -227,7 +231,12 @@ static const CGFloat kMLTextFieldThickLine = 2;
 	}
 
 	_helperDescription = helperDescription;
-	self.accessoryLabel.text = _helperDescription;
+	self.helperDescriptionLabel.text = _helperDescription;
+}
+
+- (void)setCounter:(NSString *)counter
+{
+	self.counterLabel.text = counter;
 }
 
 - (void)setErrorDescription:(nullable NSString *)errorDescription
@@ -247,16 +256,16 @@ static const CGFloat kMLTextFieldThickLine = 2;
 
 	if (!_errorDescription && self.helperDescription.length) {
 		[self updateCharacterCount];
-		self.accessoryLabel.text = self.helperDescription;
+		self.helperDescriptionLabel.text = self.helperDescription;
 		return;
 	}
 
 	if (!animated) {
-		weakSelf.accessoryLabel.text = errorDescription;
+		weakSelf.helperDescriptionLabel.text = errorDescription;
 	} else {
 		[UIView animateWithDuration:0.3 animations: ^{
-		    weakSelf.accessoryLabel.text = errorDescription;
-		    [weakSelf.accessoryLabel invalidateIntrinsicContentSize];
+		    weakSelf.helperDescriptionLabel.text = errorDescription;
+		    [weakSelf.helperDescriptionLabel invalidateIntrinsicContentSize];
 		    [weakSelf setNeedsLayout];
 		    [weakSelf layoutIfNeeded];
 		}];

--- a/MLUIUnitTests/MLTitledSingleLineTextField/MLTitledSingleLineTextFieldTest.m
+++ b/MLUIUnitTests/MLTitledSingleLineTextField/MLTitledSingleLineTextFieldTest.m
@@ -15,11 +15,14 @@
 
 @property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 @property (weak, nonatomic) IBOutlet UILabel *placeholderLabel;
-@property (weak, nonatomic) IBOutlet UILabel *accessoryLabel;
+@property (weak, nonatomic) IBOutlet UILabel *helperDescriptionLabel;
+@property (weak, nonatomic) IBOutlet UILabel *counterLabel;
 @property (weak, nonatomic) IBOutlet UIView *accessoryViewContainer;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *placeholderLeadingConstraint;
 
 @property (strong, nonatomic) MLUITextField *textField;
+
+- (void)setCounter:(NSString *)counter;
 
 @end
 
@@ -66,7 +69,15 @@
 	textField.helperDescription = @"Helper Description";
 
 	XCTAssertEqualObjects(textField.helperDescription, @"Helper Description");
-	XCTAssertEqualObjects(textField.accessoryLabel.text, @"Helper Description");
+	XCTAssertEqualObjects(textField.helperDescriptionLabel.text, @"Helper Description");
+}
+
+- (void)testSetCounter
+{
+	MLTitledSingleLineTextField *textField = self.textField;
+	textField.counter = @"0 de 60";
+
+	XCTAssertEqualObjects(textField.counterLabel.text, @"0 de 60");
 }
 
 - (void)testSetHelperDescriptionNil
@@ -75,7 +86,7 @@
 	textField.helperDescription = nil;
 
 	XCTAssertNil(textField.helperDescription);
-	XCTAssertEqualObjects(textField.accessoryLabel.text, @"");
+	XCTAssertEqualObjects(textField.helperDescriptionLabel.text, @"");
 }
 
 - (void)testAccessoryViewDefault
@@ -173,7 +184,7 @@
 
 	XCTAssertEqual(textField.placeholderLabel.textAlignment, NSTextAlignmentCenter);
 	XCTAssertEqual(textField.titleLabel.textAlignment, NSTextAlignmentCenter);
-	XCTAssertEqual(textField.accessoryLabel.textAlignment, NSTextAlignmentCenter);
+	XCTAssertEqual(textField.helperDescriptionLabel.textAlignment, NSTextAlignmentCenter);
 }
 
 - (void)testAlignLeft
@@ -183,7 +194,7 @@
 
 	XCTAssertEqual(textField.placeholderLabel.textAlignment, NSTextAlignmentLeft);
 	XCTAssertEqual(textField.titleLabel.textAlignment, NSTextAlignmentLeft);
-	XCTAssertEqual(textField.accessoryLabel.textAlignment, NSTextAlignmentLeft);
+	XCTAssertEqual(textField.helperDescriptionLabel.textAlignment, NSTextAlignmentLeft);
 }
 
 - (void)testAlignRight
@@ -193,7 +204,7 @@
 
 	XCTAssertEqual(textField.placeholderLabel.textAlignment, NSTextAlignmentRight);
 	XCTAssertEqual(textField.titleLabel.textAlignment, NSTextAlignmentRight);
-	XCTAssertEqual(textField.accessoryLabel.textAlignment, NSTextAlignmentRight);
+	XCTAssertEqual(textField.helperDescriptionLabel.textAlignment, NSTextAlignmentRight);
 }
 
 - (void)testDelegateDoesntModifyMaxCharacters


### PR DESCRIPTION
# Cambios realizados
Habilita el uso de helperDescription y que este no se reemplace en el caso de usar contador de caracteres

# Screenshots

| Antes | Después sin descriptionHelper | Después con descriptionHelper | 
| ------| --------- |:----------:|
|  ![Simulator Screen Shot - iPhone 8 - 2020-05-15 at 13 50 58](https://user-images.githubusercontent.com/49656858/82248808-bd26fa80-9916-11ea-8e21-0bde5bd4eccc.png) | ![Simulator Screen Shot - iPhone 8 - 2020-05-18 at 14 49 05](https://user-images.githubusercontent.com/49656858/82248796-b39d9280-9916-11ea-80b1-1d80bff9ae55.png) | ![Simulator Screen Shot - iPhone 8 - 2020-05-18 at 14 47 25](https://user-images.githubusercontent.com/49656858/82248630-7933f580-9916-11ea-9272-049ee56ad249.png)  |
