### PR TITLE
Update helperDescription default size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.21.1
+### Cambiado
+- 'MLUITextField': Se cambia el tamaño por defecto del helper description para soportar centrado.
+
 # v5.21.0
 ### Cambiado
 - 'MLUITextField': Se agrega el helperDescription con label separado y se coloca el contador al lado derecho.

--- a/LibraryComponents/MLTitledSingleLineTextField/assets/MLTitledLineTextField.xib
+++ b/LibraryComponents/MLTitledSingleLineTextField/assets/MLTitledLineTextField.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -31,12 +32,12 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wpY-Ad-cHL" userLabel="HelperDescription">
-                    <rect key="frame" x="0.0" y="91" width="0.0" height="0.0"/>
+                    <rect key="frame" x="0.0" y="91" width="396" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mk6-3N-faf" userLabel="Counter">
+                <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="752" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mk6-3N-faf" userLabel="Counter">
                     <rect key="frame" x="396" y="91" width="0.0" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -105,7 +106,7 @@
                 <constraint firstItem="Ttm-Hz-PLL" firstAttribute="leading" secondItem="zui-Sp-0jq" secondAttribute="leading" id="sin-ZA-P0o"/>
                 <constraint firstItem="abO-Fz-yNE" firstAttribute="top" secondItem="Ttm-Hz-PLL" secondAttribute="top" id="t2w-dC-FIK"/>
                 <constraint firstItem="ci8-92-goc" firstAttribute="top" secondItem="eB9-vN-3kQ" secondAttribute="top" constant="2" id="y9q-gt-6oa"/>
-                <constraint firstItem="mk6-3N-faf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="wpY-Ad-cHL" secondAttribute="trailing" id="ybb-cD-muJ"/>
+                <constraint firstItem="mk6-3N-faf" firstAttribute="leading" secondItem="wpY-Ad-cHL" secondAttribute="trailing" id="ybb-cD-muJ"/>
                 <constraint firstItem="abO-Fz-yNE" firstAttribute="leading" secondItem="Ttm-Hz-PLL" secondAttribute="trailing" id="zW5-iU-5p0"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>


### PR DESCRIPTION
# Cambios realizados

Elimina la separación entre el contador y el helper description, esto busca que el helperDescription ocupe todo el espacio disponible haciendo visible la alineación

# Capturas de pantalla

| Antes | Despues |
| --------- |:--------------:|
| ![Simulator Screen Shot - iPhone 8 - 2020-05-28 at 12 29 44](https://user-images.githubusercontent.com/49656858/83171589-578bf880-a0e4-11ea-9ebf-e50a0f8254ef.png) | ![Simulator Screen Shot - iPhone 8 - 2020-05-28 at 12 30 27](https://user-images.githubusercontent.com/49656858/83171602-5b1f7f80-a0e4-11ea-91ad-be98be3dd9b6.png) |

### Helper con 2 lineas

| SP Prepaid | SYI |
| --------- |:--------------:|
| ![Simulator Screen Shot - iPhone 8 - 2020-06-01 at 10 46 14](https://user-images.githubusercontent.com/49656858/83423104-86fa7800-a3f8-11ea-8f03-ad53c3351854.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2020-06-01 at 11 09 20](https://user-images.githubusercontent.com/49656858/83423112-895cd200-a3f8-11ea-84d6-25966d53b89e.png)  |