### PR TITLE
add support to custom spinner config in MLButton

### DIFF
--- a/Example/MLButton/MLButtonViewController.m
+++ b/Example/MLButton/MLButtonViewController.m
@@ -22,6 +22,7 @@
 @property (strong, nonatomic)  MLButton *primaryOptionDisabledButton;
 @property (strong, nonatomic)  MLButton *secondaryOptionButton;
 @property (strong, nonatomic)  MLButton *loadingButton;
+@property (strong, nonatomic)  MLButton *customLoadingButton;
 @property (strong, nonatomic)  MLButton *secondaryIconButton;
 @property (strong, nonatomic)  MLButton *primaryActionButtonSmall;
 
@@ -85,6 +86,18 @@
 	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[previous]-8-[button]" options:0 metrics:nil views:@{@"button" : self.loadingButton, @"previous" : self.secondaryOptionButton}]];
 	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-8-[button]-8-|" options:0 metrics:nil views:@{@"button" : self.loadingButton}]];
 	[self.loadingButton showLoadingStyle];
+
+	MLSpinnerConfig *spinnerConfig = [[MLSpinnerConfig alloc] initWithSize:MLSpinnerSizeSmall primaryColor:[UIColor ml_meli_blue] secondaryColor:[UIColor ml_meli_blue]];
+	MLButtonConfig *customConfig = [MLButtonStylesFactory configForButtonType:MLButtonTypeSecondaryAction];
+	customConfig.spinnerStyle = spinnerConfig;
+	customConfig.loadingState = [[MLButtonConfigStyle alloc] initWithContentColor:[UIColor ml_meli_white] backgroundColor:[UIColor ml_meli_white] borderColor:[UIColor ml_meli_blue]];
+	self.customLoadingButton = [[MLButton alloc] initWithConfig:customConfig];
+	[self.customLoadingButton setButtonTitle:@"Custom loading Button"];
+	[self.view addSubview:self.customLoadingButton];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[previous]-8-[button]" options:0 metrics:nil views:@{@"button" : self.customLoadingButton, @"previous" : self.loadingButton}]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-8-[button]-8-|" options:0 metrics:nil views:@{@"button" : self.customLoadingButton}]];
+	[self.customLoadingButton showLoadingStyle];
+
 	self.title = @"Buttons";
 
 	UIImage *icon = [UIImage imageNamed:@"icon-wssp"];
@@ -95,7 +108,7 @@
 	[self.secondaryIconButton setButtonTitle:@"Secondary Icon Button"];
 
 	[self.view addSubview:self.secondaryIconButton];
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[previous]-8-[button]" options:0 metrics:nil views:@{@"button" : self.secondaryIconButton, @"previous" : self.loadingButton}]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[previous]-8-[button]" options:0 metrics:nil views:@{@"button" : self.secondaryIconButton, @"previous" : self.customLoadingButton}]];
 	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-8-[button]-8-|" options:0 metrics:nil views:@{@"button" : self.secondaryIconButton}]];
 
 	MLButtonConfig *smallButtonConfig = [MLButtonStylesFactory configForButtonType:MLButtonTypePrimaryAction withSize:MLButtonSizeSmall];

--- a/LibraryComponents/MLButton/classes/MLButton.m
+++ b/LibraryComponents/MLButton/classes/MLButton.m
@@ -336,9 +336,12 @@ static const CGFloat kMLButtonSmallVerticalPadding = 11.0f;
 
 - (MLSpinnerConfig *)spinnerConfig
 {
-	if (!_spinnerConfig) {
+	if (self.config.spinnerStyle) {
+		_spinnerConfig = self.config.spinnerStyle;
+	} else if (!_spinnerConfig) {
 		_spinnerConfig = [[MLSpinnerConfig alloc] initWithSize:MLSpinnerSizeSmall primaryColor:[UIColor whiteColor] secondaryColor:[UIColor whiteColor]];
 	}
+
 	return _spinnerConfig;
 }
 

--- a/LibraryComponents/MLButton/classes/MLButtonConfig.h
+++ b/LibraryComponents/MLButton/classes/MLButtonConfig.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "MLButtonConfigStyle.h"
 #import "MLButtonStylesFactory.h"
+#import "MLSpinner.h"
 
 @interface MLButtonConfig : NSObject
 
@@ -16,6 +17,7 @@
 @property (nonatomic, strong) MLButtonConfigStyle *highlightedState;
 @property (nonatomic, strong) MLButtonConfigStyle *disableState;
 @property (nonatomic, strong) MLButtonConfigStyle *loadingState;
+@property (nonatomic, strong) MLSpinnerConfig *spinnerStyle;
 @property (nonatomic, assign) MLButtonSize buttonSize;
 
 @end

--- a/MLUIUnitTests/MLButton/MLButtonTest.m
+++ b/MLUIUnitTests/MLButton/MLButtonTest.m
@@ -28,6 +28,7 @@
 @property (nonatomic, assign) CGFloat verticalPadding;
 @property (nonatomic, assign) CGFloat fontSize;
 @property (nonatomic, strong) NSArray <NSLayoutConstraint *> *verticalPaddingConstraints;
+@property (nonatomic, strong) MLSpinnerConfig *spinnerConfig;
 
 - (void)updateLookAndFeel;
 - (void)updateButtonIcon:(UIImage *_Nullable)image;
@@ -375,6 +376,28 @@
 	for (NSLayoutConstraint *constraint in  button.verticalPaddingConstraints) {
 		XCTAssertEqual(constraint.constant, 15.0f);
 	}
+}
+
+- (void)testSpinnerWithCustomConfig
+{
+	// when
+	MLSpinnerConfig *spinnerConfig = [[MLSpinnerConfig alloc] initWithSize:MLSpinnerSizeSmall primaryColor:[UIColor redColor] secondaryColor:[UIColor redColor]];
+	MLButtonConfig *customConfig = [MLButtonStylesFactory configForButtonType:MLButtonTypeSecondaryAction];
+	customConfig.spinnerStyle = spinnerConfig;
+	customConfig.loadingState = [[MLButtonConfigStyle alloc] initWithContentColor:[UIColor blueColor] backgroundColor:[UIColor blueColor] borderColor:[UIColor blueColor]];
+	MLButton *button = [[MLButton alloc] initWithConfig:customConfig];
+	// Then
+	XCTAssertEqual(button.spinnerConfig, spinnerConfig);
+}
+
+- (void)testSpinnerWithDefaultConfig
+{
+	// when
+	MLButton *button = [[MLButton alloc] initWithConfig:[MLButtonStylesFactory configForButtonType:MLButtonTypePrimaryAction withSize:MLButtonSizeSmall]];
+	// Then
+	XCTAssertEqual(button.spinnerConfig.primaryColor, [UIColor whiteColor]);
+	XCTAssertEqual(button.spinnerConfig.secondaryColor, [UIColor whiteColor]);
+	XCTAssertEqual(button.spinnerConfig.spinnerSize, MLSpinnerSizeSmall);
 }
 
 @end


### PR DESCRIPTION
### Contenido

Se da soporte a `MLButton` para customizar el color del `spinner` mediante `MLButtonConfig`


## Capturas

|Antes| Despues|
|--|--|
| ![2020-06-03 19 03 15](https://user-images.githubusercontent.com/18092648/83697571-5d467a00-a5cd-11ea-90d8-b45ab9df2407.gif)| ![2020-06-03 19 03 47](https://user-images.githubusercontent.com/18092648/83697549-4f90f480-a5cd-11ea-953f-c57d125f4011.gif) | 


## Como probar.

En la test app ver el casos de MLButton. 