### PR TITLE
Update counter format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.21.2
+### Cambiado
+- 'MLUITextField': Se cambia el formateo del contador.
+
 # v5.21.1
 ### Cambiado
 - 'MLUITextField': Se cambia el tamaño por defecto del helper description para soportar centrado.

--- a/LibraryComponents/MLTitledSingleLineTextField/assets/en.lproj/MLTitledSingleLineTextField.strings
+++ b/LibraryComponents/MLTitledSingleLineTextField/assets/en.lproj/MLTitledSingleLineTextField.strings
@@ -6,4 +6,4 @@
   Copyright © 2016 MercadoLibre. All rights reserved.
 */
 
-"CHARACTER_COUNT_FORMAT" = "%lu of %lu";
+"CHARACTER_COUNT_FORMAT" = "%lu / %lu";

--- a/LibraryComponents/MLTitledSingleLineTextField/assets/es.lproj/MLTitledSingleLineTextField.strings
+++ b/LibraryComponents/MLTitledSingleLineTextField/assets/es.lproj/MLTitledSingleLineTextField.strings
@@ -6,4 +6,4 @@
   Copyright © 2016 MercadoLibre. All rights reserved.
 */
 
-"CHARACTER_COUNT_FORMAT" = "%lu de %lu";
+"CHARACTER_COUNT_FORMAT" = "%lu / %lu";

--- a/LibraryComponents/MLTitledSingleLineTextField/assets/pt.lproj/MLTitledSingleLineTextField.strings
+++ b/LibraryComponents/MLTitledSingleLineTextField/assets/pt.lproj/MLTitledSingleLineTextField.strings
@@ -6,4 +6,4 @@
   Copyright © 2016 MercadoLibre. All rights reserved.
 */
 
-"CHARACTER_COUNT_FORMAT" = "%lu de %lu";
+"CHARACTER_COUNT_FORMAT" = "%lu / %lu";


### PR DESCRIPTION
# Cambios realizados

Se cambia el formateo del contador para separar la cantidad de caracteres utilizados y la cantidad de caracteres totales por un simbolo de `/`

# Screenshots

| Antes | Despues |
| --------- |:--------------:|
| ![Simulator Screen Shot - iPhone 8 Plus - 2020-06-03 at 22 46 40](https://user-images.githubusercontent.com/49656858/83709229-1320c100-a5ec-11ea-86a2-5623a9591901.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2020-06-03 at 22 21 09](https://user-images.githubusercontent.com/49656858/83709195-03a17800-a5ec-11ea-8fec-c5f8a3c2a77a.png) |