### PR TITLE
[MLTitledMultiLineTextField] On set accessibilityIdentifier sets the textView accessibilityIdentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Sin publicar
 ### Cambiado
+- 'MLTitledMultiLineTextField': Al setear el accessibilityIdentifier se lo asigna al textView.
 - Se comprimen los recursos con `kelli compress`
 
 # v5.21.1
@@ -31,11 +32,11 @@
 # v5.18.0
 - Fix modal full screen
 
-# v5.17.0 
+# v5.17.0
 ### Agregado
-- 'MLRadioButton': se corrigen los colores para que muestre los correspondientes a cada plataforma. 
- 
-### Cambiado 
+- 'MLRadioButton': se corrigen los colores para que muestre los correspondientes a cada plataforma.
+
+### Cambiado
 - `MLTitledSingleLineTextField`: Soporte para setear error en MLTitledSingleLineTextField sin animación.
 
 # v5.16.0

--- a/LibraryComponents/MLTitledMultiLineTextField/classes/MLTitledMultiLineTextField.m
+++ b/LibraryComponents/MLTitledMultiLineTextField/classes/MLTitledMultiLineTextField.m
@@ -119,6 +119,16 @@
 
 #pragma mark Custom Setters
 
+- (NSString *)accessibilityIdentifier
+{
+	return self.textView.accessibilityIdentifier;
+}
+
+- (void)setAccessibilityIdentifier:(NSString *)accessibilityIdentifier
+{
+	[self.textView setAccessibilityIdentifier:accessibilityIdentifier];
+}
+
 - (void)setText:(NSString *)text
 {
 	if (![self validateLength:text]) {

--- a/LibraryComponents/MLTitledSingleLineTextField/classes/MLTitledSingleLineTextField.h
+++ b/LibraryComponents/MLTitledSingleLineTextField/classes/MLTitledSingleLineTextField.h
@@ -204,16 +204,6 @@ typedef NS_ENUM (NSInteger, MLTitledTextFieldState) {
  */
 - (void)setErrorDescription:(nullable NSString *)errorDescription animated:(BOOL)animated;
 
-/**
-   Permits to set accessibilityIdentifier on text field
- */
-- (void)setAccessibilityIdentifier:(nullable NSString *)accessibilityIdentifier;
-
-/**
-   Permits to get accessibilityIdentifier on text field
- */
-- (NSString *)accessibilityIdentifier;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MLUIUnitTests/MLTitledMultiLineTextField/MLTitledMultiLineTextFieldTest.m
+++ b/MLUIUnitTests/MLTitledMultiLineTextField/MLTitledMultiLineTextFieldTest.m
@@ -34,6 +34,20 @@
 	return [[MLTitledMultiLineTextField alloc] init];
 }
 
+- (void)testSetAccessibilityIdentifier_ShouldSetAccessibilityIdentifierOnTextView
+{
+	// Given
+	MLTitledMultiLineTextField *textField = self.textField;
+	NSString *accessibilityIdentifier = @"textFieldAccessibilityIdentifier";
+
+	// When
+	textField.accessibilityIdentifier = accessibilityIdentifier;
+
+	// Then
+	XCTAssertEqualObjects(textField.accessibilityIdentifier, accessibilityIdentifier);
+	XCTAssertEqualObjects(textField.textView.accessibilityIdentifier, accessibilityIdentifier);
+}
+
 - (void)testSetTextNil
 {
 	MLTitledMultiLineTextField *textField = self.textField;


### PR DESCRIPTION
En el PR #90 se hace override del comportamiento definido por el protocolo [`UIAccessibilityIdentification`](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification) de `MLTitledSingleLineTextField`.

La clase `MLTitledMultiLineTextField` hereda de `MLTitledSingleLineTextField` y pierde el comportamiento esperado por el protocolo [`UIAccessibilityIdentification`](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification).

Se soluciona tomando la misma estrategia del PR #90, asignando el `accessibilityIdentifier` al textView.

Por último, borro las firmas agregadas en `MLTitledSingleLineTextField.h` en el PR #90 ya que son redundantes porque UIView implementa el protocolo [`UIAccessibilityIdentification`](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification).