### PR TITLE
migrate to static

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
       - run:
           name: Run Pod Lint
           command: bundle exec pod lib lint MLUI.podspec --allow-warnings --sources='https://github.com/CocoaPods/Specs'
+          no_output_timeout: 7200
       - run:
           name: Run Uncrustify
           command: ./scripts/uncrustify.sh --check --path LibraryComponents Example MLUIUnitTests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.26.0
+### Cambiado
+- Migración a Static Framework
+
 # v5.25.0
 ### Agregado
 - Soporte a Xcode 12

--- a/MLUI.podspec
+++ b/MLUI.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/mercadolibre/fury_mobile-ios-ui.git", :tag => s.version.to_s }
   s.platform         = :ios, '10.0'
   s.requires_arc     = true
+  s.static_framework = true
 
   s.subspec 'StyleSheet' do |styleSheet|
     styleSheet.source_files = "LibraryComponents/StyleSheet/classes/*.{h,m}"

--- a/MLUI.podspec
+++ b/MLUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MLUI"
-  s.version          = "5.25.0"
+  s.version          = "5.26.0"
   s.summary          = "MercadoLibre mobile ios UI components"
   s.homepage         = "https://github.com/mercadolibre"
   s.license          = "Apache License, Version 2.0"

--- a/MLUI.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/MLUI.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>

--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,7 @@ project 'MLUI.xcodeproj'
 
 use_frameworks!
 
+install! 'cocoapods', disable_input_output_paths: true
 platform :ios, '10.0'
 
 install! 'cocoapods',

--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,4 @@
+source 'git@github.com:mercadolibre/mobile-ios_specs.git'
 source 'https://cdn.cocoapods.org'
 
 workspace 'MLUI'


### PR DESCRIPTION
## Descripción
Hola les comparto este PR sobre la migración de esta lib a estático
- guía de migración: https://sites.google.com/mercadolibre.com/mobile/arquitectura/ios/frameworks-est%C3%A1ticos

## Motivos para mergear estos cambios
- Migrar este framework a estático nos ayuda a reducir el tiempo de startup time que tenemos actualmente en nuestras apps
- Post con resultados del trabajo en MP: https://meli.workplace.com/.../startup.../413332689981354

![Simulator Screen Shot - iPhone 11 - 2021-06-11 at 11 37 55](https://user-images.githubusercontent.com/71398734/121721122-8388da80-caa9-11eb-8565-b85528baad2d.png)
![Simulator Screen Shot - iPhone 11 - 2021-06-11 at 11 38 00](https://user-images.githubusercontent.com/71398734/121721124-84ba0780-caa9-11eb-8f5b-b57e99c19929.png)
![Simulator Screen Shot - iPhone 11 - 2021-06-11 at 11 38 05](https://user-images.githubusercontent.com/71398734/121721130-8683cb00-caa9-11eb-9b07-edb758538319.png)
