### PR TITLE
Migracion iOS13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v6.0.0
+### Migrated
+- Migración iOS13
+
 # v5.26.1
 ### Cambiado
 - Rollback  a Static Framework debido a que hay otras libs dependientes que de momento no están migradas a estáticas

--- a/MLUI.podspec
+++ b/MLUI.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name             = "MLUI"
-  s.version          = "5.26.1"
+  s.version          = "6.0.0"
   s.summary          = "MercadoLibre mobile ios UI components"
   s.homepage         = "https://github.com/mercadolibre"
   s.license          = "Apache License, Version 2.0"
   s.author           = { "mobile arquitectura @ meli" => "mobile-arquitectura@mercadolibre.com" }
   s.source           = { :git => "https://github.com/mercadolibre/fury_mobile-ios-ui.git", :tag => s.version.to_s }
-  s.platform         = :ios, '10.0'
+  s.platform         = :ios, '13.0'
   s.requires_arc     = true
 
   s.subspec 'StyleSheet' do |styleSheet|

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ project 'MLUI.xcodeproj'
 use_frameworks!
 
 install! 'cocoapods', disable_input_output_paths: true
-platform :ios, '10.0'
+platform :ios, '13.0'
 
 install! 'cocoapods',
   :generate_multiple_pod_projects => true,

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,54 +1,54 @@
 PODS:
   - FXBlurView (1.6.4)
   - JRSwizzle (1.0)
-  - MLUI (5.24.0):
-    - MLUI/ActionButton (= 5.24.0)
-    - MLUI/Core (= 5.24.0)
-    - MLUI/Helpers (= 5.24.0)
-    - MLUI/MLButton (= 5.24.0)
-    - MLUI/MLCheckBox (= 5.24.0)
-    - MLUI/MLColorPalette (= 5.24.0)
-    - MLUI/MLContextualMenu (= 5.24.0)
-    - MLUI/MLFonts (= 5.24.0)
-    - MLUI/MLFullscreenModal (= 5.24.0)
-    - MLUI/MLGenericErrorView (= 5.24.0)
-    - MLUI/MLHeader (= 5.24.0)
-    - MLUI/MLHtml (= 5.24.0)
-    - MLUI/MLModal (= 5.24.0)
-    - MLUI/MLRadioButton (= 5.24.0)
-    - MLUI/MLSnackBar (= 5.24.0)
-    - MLUI/MLSpacing (= 5.24.0)
-    - MLUI/MLSpinner (= 5.24.0)
-    - MLUI/MLSwitch (= 5.24.0)
-    - MLUI/MLTextView (= 5.24.0)
-    - MLUI/MLTitledMultiLineTextField (= 5.24.0)
-    - MLUI/MLTitledSingleLineTextField (= 5.24.0)
-    - MLUI/PriceView (= 5.24.0)
-    - MLUI/SnackBarView (= 5.24.0)
-    - MLUI/StyleSheet (= 5.24.0)
-  - MLUI/ActionButton (5.24.0):
+  - MLUI (5.26.1):
+    - MLUI/ActionButton (= 5.26.1)
+    - MLUI/Core (= 5.26.1)
+    - MLUI/Helpers (= 5.26.1)
+    - MLUI/MLButton (= 5.26.1)
+    - MLUI/MLCheckBox (= 5.26.1)
+    - MLUI/MLColorPalette (= 5.26.1)
+    - MLUI/MLContextualMenu (= 5.26.1)
+    - MLUI/MLFonts (= 5.26.1)
+    - MLUI/MLFullscreenModal (= 5.26.1)
+    - MLUI/MLGenericErrorView (= 5.26.1)
+    - MLUI/MLHeader (= 5.26.1)
+    - MLUI/MLHtml (= 5.26.1)
+    - MLUI/MLModal (= 5.26.1)
+    - MLUI/MLRadioButton (= 5.26.1)
+    - MLUI/MLSnackBar (= 5.26.1)
+    - MLUI/MLSpacing (= 5.26.1)
+    - MLUI/MLSpinner (= 5.26.1)
+    - MLUI/MLSwitch (= 5.26.1)
+    - MLUI/MLTextView (= 5.26.1)
+    - MLUI/MLTitledMultiLineTextField (= 5.26.1)
+    - MLUI/MLTitledSingleLineTextField (= 5.26.1)
+    - MLUI/PriceView (= 5.26.1)
+    - MLUI/SnackBarView (= 5.26.1)
+    - MLUI/StyleSheet (= 5.26.1)
+  - MLUI/ActionButton (5.26.1):
     - MLUI/Core
-  - MLUI/Core (5.24.0):
+  - MLUI/Core (5.26.1):
     - MLUI/MLFonts
-  - MLUI/Helpers (5.24.0)
-  - MLUI/MLButton (5.24.0):
+  - MLUI/Helpers (5.26.1)
+  - MLUI/MLButton (5.26.1):
     - MLUI/Core
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/MLSpinner
     - MLUI/StyleSheet
-  - MLUI/MLCheckBox (5.24.0):
+  - MLUI/MLCheckBox (5.26.1):
     - MLUI/MLColorPalette
     - MLUI/StyleSheet
-  - MLUI/MLColorPalette (5.24.0)
-  - MLUI/MLContextualMenu (5.24.0):
+  - MLUI/MLColorPalette (5.26.1)
+  - MLUI/MLContextualMenu (5.26.1):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
-  - MLUI/MLFonts (5.24.0):
+  - MLUI/MLFonts (5.26.1):
     - JRSwizzle (= 1.0)
     - MLUI/Helpers
     - MLUI/StyleSheet
-  - MLUI/MLFullscreenModal (5.24.0):
+  - MLUI/MLFullscreenModal (5.26.1):
     - FXBlurView (~> 1.6)
     - MLUI/Core
     - MLUI/MLButton
@@ -56,58 +56,58 @@ PODS:
     - MLUI/MLFonts
     - MLUI/MLHeader
     - MLUI/StyleSheet
-  - MLUI/MLGenericErrorView (5.24.0):
+  - MLUI/MLGenericErrorView (5.26.1):
     - MLUI/MLButton
     - MLUI/MLColorPalette
     - MLUI/MLSpacing
-  - MLUI/MLHeader (5.24.0):
+  - MLUI/MLHeader (5.26.1):
     - MLUI/MLColorPalette
     - MLUI/StyleSheet
-  - MLUI/MLHtml (5.24.0):
+  - MLUI/MLHtml (5.26.1):
     - MLUI/MLFonts
-  - MLUI/MLModal (5.24.0):
+  - MLUI/MLModal (5.26.1):
     - FXBlurView (~> 1.6)
     - MLUI/Core
     - MLUI/MLButton
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/StyleSheet
-  - MLUI/MLRadioButton (5.24.0):
+  - MLUI/MLRadioButton (5.26.1):
     - MLUI/StyleSheet
-  - MLUI/MLSnackBar (5.24.0):
+  - MLUI/MLSnackBar (5.26.1):
     - MLUI/Helpers
     - MLUI/MLButton
     - MLUI/MLColorPalette
     - MLUI/MLFonts
-  - MLUI/MLSpacing (5.24.0):
+  - MLUI/MLSpacing (5.26.1):
     - JRSwizzle (= 1.0)
     - MLUI/MLFonts
-  - MLUI/MLSpinner (5.24.0):
+  - MLUI/MLSpinner (5.26.1):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/StyleSheet
-  - MLUI/MLSwitch (5.24.0):
+  - MLUI/MLSwitch (5.26.1):
     - MLUI/Helpers
     - MLUI/MLColorPalette
-  - MLUI/MLTextView (5.24.0):
+  - MLUI/MLTextView (5.26.1):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
-  - MLUI/MLTitledMultiLineTextField (5.24.0):
+  - MLUI/MLTitledMultiLineTextField (5.26.1):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/MLTitledSingleLineTextField
     - MLUI/StyleSheet
-  - MLUI/MLTitledSingleLineTextField (5.24.0):
+  - MLUI/MLTitledSingleLineTextField (5.26.1):
     - MLUI/MLColorPalette
     - MLUI/MLFonts
     - MLUI/StyleSheet
-  - MLUI/PriceView (5.24.0):
+  - MLUI/PriceView (5.26.1):
     - MLUI/Core
     - MLUI/MLFonts
-  - MLUI/SnackBarView (5.24.0):
+  - MLUI/SnackBarView (5.26.1):
     - MLUI/Helpers
     - MLUI/MLFonts
-  - MLUI/StyleSheet (5.24.0)
+  - MLUI/StyleSheet (5.26.1)
   - OCMock (3.4.1)
 
 DEPENDENCIES:
@@ -128,9 +128,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
   JRSwizzle: dd5ead5d913a0f29e7f558200165849f006bb1e3
-  MLUI: adbe6d46e7df979ccd0a14e3ac751aa6d98d2c85
+  MLUI: eb1e67a4c3314745fb472a736ee017e6c9b77d65
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
 
-PODFILE CHECKSUM: 20033be737b1c449f49db00bb2c6b81c04476827
+PODFILE CHECKSUM: bedcb3c40bf77af8b26ec485ced78cc47dff44f7
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
<h1>Migración iOS13</h1>Desde el squad de Platform Updates de Arquitectura Mobile, tenemos el compromiso de velar por mantener el stack tecnológico actualizado, es por ello que la última parte de la migración se va realizar de la siguiente manera: <br /><br /><img src='https://user-images.githubusercontent.com/86304959/161846857-4bbc55eb-9f05-4b5b-9bdd-28e46d539668.png' /><h2>Ninguna lib core podrá realizar esta migración hasta que las libs frontend se hayan migrado por completo</h2><h3>¿Qué es una lib core?</h3>La lib es utilizada por dos o más otras librerias.<h3>¿Qué es una lib frontend?</h3>La lib no es utilizada por otras librerias. <br />Si tienes algún problema, busca nuestro squad de <a href='https://sites.google.com/mercadolibre.com/mobile/team/qui%C3%A9nes-somos#h.34n3nvj337r3'>Plataform Updates</a> o a través de nuestro canal de slack <a href='https://join.slack.com/share/enQtMzMzMjEyMzI0MTA3NS04MjIxZTc0NzI1YTU4OTQ5ZTIzMWQ3YWQwYmVmYzZjY2JkOTQ3ZTczZDc4ZjdmMWU2Njk0NjliNGRhNGRiODJk'>#help-migracion-ios13.</a><br /><br />Saludos!