### PR TITLE
Source publico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-This library was deprefacted in favor of AndesUI
+This library was deprecated in favor of AndesUI
 
 ## [5.26.3] - 2022-10-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.26.3
+### Cambiado
+- Migracion de source publico en nexus para soportar fury
+
 # v5.26.1
 ### Cambiado
 - Rollback  a Static Framework debido a que hay otras libs dependientes que de momento no están migradas a estáticas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
-# v5.26.3
-### Cambiado
+# Changelog
+This library was deprefacted in favor of AndesUI
+
+## [5.26.3] - 2022-10-25
+### Added
 - Migracion de source publico en nexus para soportar fury
 
-# v5.26.1
-### Cambiado
+## [5.26.1] - 2020-11-09
+### Changed
 - Rollback  a Static Framework debido a que hay otras libs dependientes que de momento no están migradas a estáticas
 
-# v5.26.0
-### Cambiado
+## [5.26.0] - 2020-11-09
+### Changed
 - Migración a Static Framework
 
-# v5.25.0
-### Agregado
+## [5.25.0] - 2020-11-09
+### Added
 - Soporte a Xcode 12
 
 # v5.24.0

--- a/MLUI.podspec
+++ b/MLUI.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/mercadolibre"
   s.license          = "Apache License, Version 2.0"
   s.author           = { "mobile arquitectura @ meli" => "mobile-arquitectura@mercadolibre.com" }
-  s.source           = { :git => "https://github.com/mercadolibre/fury_mobile-ios-ui.git", :tag => s.version }
+  s.source           = { :http => "https://artifacts.mercadolibre.com/repository/ios-releases/MLUI/#{s.version}/MLUI.zip" }
   s.platform         = :ios, '13.0'
   s.requires_arc     = true
 


### PR DESCRIPTION
Como proceso previo a la migración a fury, cambio la URL de los sources de la lib, para apuntar al servidor nexus, ya que cuando se migre a fury, el repo pasara a ser privado 